### PR TITLE
Fix double instantiation problem

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -55,7 +55,8 @@ jobs:
 
 
 install:
-  - sudo apt-get install -y libzmq3-dev
+  - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then sudo apt-get install -y libzmq3-dev; fi
+  - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew install zmq; fi
 
   # install our own nodejs to get a reasonable version
   - rm -rf ~/.nvm && git clone https://github.com/creationix/nvm.git ~/.nvm && (cd ~/.nvm && git checkout `git describe --abbrev=0 --tags`) && source ~/.nvm/nvm.sh && nvm install $TRAVIS_NODE_VERSION

--- a/.travis.yml
+++ b/.travis.yml
@@ -55,8 +55,8 @@ jobs:
 
 
 install:
+  # configuration borrowed from holochain-rust Makefile, showing how to install zmq for ubuntu trusty on travis
   - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then
-      # configuration borrowed from holochain-rust Makefile, showing how to install zmq for ubuntu trusty on travis
       echo "deb http://download.opensuse.org/repositories/network:/messaging:/zeromq:/release-stable/xUbuntu_14.04/ ./" >> /etc/apt/sources.list;
       wget https://download.opensuse.org/repositories/network:/messaging:/zeromq:/release-stable/xUbuntu_14.04/Release.key -O- | sudo apt-key add;
       sudo apt-get update -qq;

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,4 @@
-sudo: false
+sudo: true
 language: rust
 rust:
 - nightly
@@ -53,7 +53,10 @@ jobs:
       - echo "Deploying to NPM..."
       - node publish.js --publish
 
+
 install:
+  - sudo apt-get install -y libzmq3-dev
+
   # install our own nodejs to get a reasonable version
   - rm -rf ~/.nvm && git clone https://github.com/creationix/nvm.git ~/.nvm && (cd ~/.nvm && git checkout `git describe --abbrev=0 --tags`) && source ~/.nvm/nvm.sh && nvm install $TRAVIS_NODE_VERSION
   

--- a/.travis.yml
+++ b/.travis.yml
@@ -55,7 +55,13 @@ jobs:
 
 
 install:
-  - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then sudo apt-get install -y libzmq3-dev; fi
+  - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then
+      # configuration borrowed from holochain-rust Makefile, showing how to install zmq for ubuntu trusty on travis
+      echo "deb http://download.opensuse.org/repositories/network:/messaging:/zeromq:/release-stable/xUbuntu_14.04/ ./" >> /etc/apt/sources.list;
+      wget https://download.opensuse.org/repositories/network:/messaging:/zeromq:/release-stable/xUbuntu_14.04/Release.key -O- | sudo apt-key add;
+      sudo apt-get update -qq;
+      sudo apt-get install libzmq3-dev;
+    fi
   - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew install zmq; fi
 
   # install our own nodejs to get a reasonable version

--- a/native/Cargo.lock
+++ b/native/Cargo.lock
@@ -56,6 +56,11 @@ dependencies = [
 ]
 
 [[package]]
+name = "boolinator"
+version = "2.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
 name = "byte-tools"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -111,7 +116,7 @@ dependencies = [
  "nom 3.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.80 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde-hjson 0.8.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde_json 1.0.32 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_json 1.0.33 (registry+https://github.com/rust-lang/crates.io-index)",
  "toml 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "yaml-rust 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -140,6 +145,11 @@ version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
+name = "error-chain"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
 name = "failure"
 version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -153,9 +163,9 @@ name = "failure_derive"
 version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "proc-macro2 0.4.20 (registry+https://github.com/rust-lang/crates.io-index)",
- "quote 0.6.9 (registry+https://github.com/rust-lang/crates.io-index)",
- "syn 0.15.18 (registry+https://github.com/rust-lang/crates.io-index)",
+ "proc-macro2 0.4.23 (registry+https://github.com/rust-lang/crates.io-index)",
+ "quote 0.6.10 (registry+https://github.com/rust-lang/crates.io-index)",
+ "syn 0.15.20 (registry+https://github.com/rust-lang/crates.io-index)",
  "synstructure 0.10.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -302,33 +312,21 @@ name = "holochain-node"
 version = "0.1.0"
 dependencies = [
  "base64 0.9.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "holochain_agent 0.0.1 (git+https://github.com/holochain/holochain-rust?branch=develop)",
  "holochain_cas_implementations 0.0.1 (git+https://github.com/holochain/holochain-rust?branch=develop)",
+ "holochain_container_api 0.0.1 (git+https://github.com/holochain/holochain-rust?branch=develop)",
  "holochain_core 0.0.1 (git+https://github.com/holochain/holochain-rust?branch=develop)",
- "holochain_core_api 0.0.1 (git+https://github.com/holochain/holochain-rust?branch=develop)",
  "holochain_core_types 0.0.1 (git+https://github.com/holochain/holochain-rust?branch=develop)",
  "holochain_dna 0.0.1 (git+https://github.com/holochain/holochain-rust?branch=develop)",
  "neon 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "neon-build 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde_json 1.0.32 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_json 1.0.33 (registry+https://github.com/rust-lang/crates.io-index)",
  "tempfile 3.0.4 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
-name = "holochain_agent"
-version = "0.0.1"
-source = "git+https://github.com/holochain/holochain-rust?branch=develop#1c726e7d5da5239131a781c24b1f6151b67cfefb"
-dependencies = [
- "holochain_core_types 0.0.1 (git+https://github.com/holochain/holochain-rust?branch=develop)",
- "serde 1.0.80 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde_derive 1.0.80 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde_json 1.0.32 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "holochain_cas_implementations"
 version = "0.0.1"
-source = "git+https://github.com/holochain/holochain-rust?branch=develop#1c726e7d5da5239131a781c24b1f6151b67cfefb"
+source = "git+https://github.com/holochain/holochain-rust?branch=develop#8e9da77855312dcf1c7134537332f12ff16313d6"
 dependencies = [
  "futures-preview 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "holochain_core_types 0.0.1 (git+https://github.com/holochain/holochain-rust?branch=develop)",
@@ -339,23 +337,40 @@ dependencies = [
  "riker-patterns 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.80 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_derive 1.0.80 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde_json 1.0.32 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_json 1.0.33 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_test 1.0.80 (registry+https://github.com/rust-lang/crates.io-index)",
  "snowflake 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "unwrap_to 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "walkdir 2.2.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "uuid 0.7.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "walkdir 2.2.7 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "holochain_container_api"
+version = "0.0.1"
+source = "git+https://github.com/holochain/holochain-rust?branch=develop#8e9da77855312dcf1c7134537332f12ff16313d6"
+dependencies = [
+ "boolinator 2.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "futures-preview 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "holochain_cas_implementations 0.0.1 (git+https://github.com/holochain/holochain-rust?branch=develop)",
+ "holochain_core 0.0.1 (git+https://github.com/holochain/holochain-rust?branch=develop)",
+ "holochain_core_types 0.0.1 (git+https://github.com/holochain/holochain-rust?branch=develop)",
+ "holochain_dna 0.0.1 (git+https://github.com/holochain/holochain-rust?branch=develop)",
+ "serde 1.0.80 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_derive 1.0.80 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tempfile 3.0.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "toml 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "holochain_core"
 version = "0.0.1"
-source = "git+https://github.com/holochain/holochain-rust?branch=develop#1c726e7d5da5239131a781c24b1f6151b67cfefb"
+source = "git+https://github.com/holochain/holochain-rust?branch=develop#8e9da77855312dcf1c7134537332f12ff16313d6"
 dependencies = [
  "bitflags 1.0.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "chrono 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "config 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures-preview 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "holochain_agent 0.0.1 (git+https://github.com/holochain/holochain-rust?branch=develop)",
  "holochain_cas_implementations 0.0.1 (git+https://github.com/holochain/holochain-rust?branch=develop)",
  "holochain_core_types 0.0.1 (git+https://github.com/holochain/holochain-rust?branch=develop)",
  "holochain_core_types_derive 0.0.1 (git+https://github.com/holochain/holochain-rust?branch=develop)",
@@ -366,90 +381,115 @@ dependencies = [
  "multihash 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "num-derive 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "num-traits 0.2.6 (registry+https://github.com/rust-lang/crates.io-index)",
- "regex 1.0.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "regex 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "rust-base58 0.0.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.80 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_derive 1.0.80 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde_json 1.0.32 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_json 1.0.33 (registry+https://github.com/rust-lang/crates.io-index)",
  "snowflake 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "toml 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "unwrap_to 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "wasmi 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
-name = "holochain_core_api"
-version = "0.0.1"
-source = "git+https://github.com/holochain/holochain-rust?branch=develop#1c726e7d5da5239131a781c24b1f6151b67cfefb"
-dependencies = [
- "futures-preview 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "holochain_agent 0.0.1 (git+https://github.com/holochain/holochain-rust?branch=develop)",
- "holochain_core 0.0.1 (git+https://github.com/holochain/holochain-rust?branch=develop)",
- "holochain_core_types 0.0.1 (git+https://github.com/holochain/holochain-rust?branch=develop)",
- "holochain_dna 0.0.1 (git+https://github.com/holochain/holochain-rust?branch=develop)",
- "tempfile 3.0.4 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
 name = "holochain_core_types"
 version = "0.0.1"
-source = "git+https://github.com/holochain/holochain-rust?branch=develop#1c726e7d5da5239131a781c24b1f6151b67cfefb"
+source = "git+https://github.com/holochain/holochain-rust?branch=develop#8e9da77855312dcf1c7134537332f12ff16313d6"
 dependencies = [
  "bitflags 1.0.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures-preview 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "holochain_core_types_derive 0.0.1 (git+https://github.com/holochain/holochain-rust?branch=develop)",
  "multihash 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "objekt 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "rust-base58 0.0.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.80 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_derive 1.0.80 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde_json 1.0.32 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_json 1.0.33 (registry+https://github.com/rust-lang/crates.io-index)",
  "snowflake 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "uuid 0.7.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "holochain_core_types_derive"
 version = "0.0.1"
-source = "git+https://github.com/holochain/holochain-rust?branch=develop#1c726e7d5da5239131a781c24b1f6151b67cfefb"
+source = "git+https://github.com/holochain/holochain-rust?branch=develop#8e9da77855312dcf1c7134537332f12ff16313d6"
 dependencies = [
- "quote 0.6.9 (registry+https://github.com/rust-lang/crates.io-index)",
+ "quote 0.6.10 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.80 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde_json 1.0.32 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_json 1.0.33 (registry+https://github.com/rust-lang/crates.io-index)",
  "syn 0.14.9 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "holochain_dna"
 version = "0.0.1"
-source = "git+https://github.com/holochain/holochain-rust?branch=develop#1c726e7d5da5239131a781c24b1f6151b67cfefb"
+source = "git+https://github.com/holochain/holochain-rust?branch=develop#8e9da77855312dcf1c7134537332f12ff16313d6"
 dependencies = [
  "base64 0.9.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "holochain_core_types 0.0.1 (git+https://github.com/holochain/holochain-rust?branch=develop)",
  "holochain_core_types_derive 0.0.1 (git+https://github.com/holochain/holochain-rust?branch=develop)",
  "serde 1.0.80 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_derive 1.0.80 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde_json 1.0.32 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_json 1.0.33 (registry+https://github.com/rust-lang/crates.io-index)",
  "uuid 0.6.5 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "holochain_net"
 version = "0.0.1"
-source = "git+https://github.com/holochain/holochain-rust?branch=develop#1c726e7d5da5239131a781c24b1f6151b67cfefb"
+source = "git+https://github.com/holochain/holochain-rust?branch=develop#8e9da77855312dcf1c7134537332f12ff16313d6"
 dependencies = [
  "base64 0.9.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "failure 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde_json 1.0.32 (registry+https://github.com/rust-lang/crates.io-index)",
+ "holochain_core_types 0.0.1 (git+https://github.com/holochain/holochain-rust?branch=develop)",
+ "holochain_net_connection 0.1.0 (git+https://github.com/holochain/holochain-rust?branch=develop)",
+ "holochain_net_ipc 0.1.0 (git+https://github.com/holochain/holochain-rust?branch=develop)",
+ "serde_json 1.0.33 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "holochain_net_connection"
+version = "0.1.0"
+source = "git+https://github.com/holochain/holochain-rust?branch=develop#8e9da77855312dcf1c7134537332f12ff16313d6"
+dependencies = [
+ "byteorder 1.2.7 (registry+https://github.com/rust-lang/crates.io-index)",
+ "failure 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "holochain_core_types 0.0.1 (git+https://github.com/holochain/holochain-rust?branch=develop)",
+ "holochain_core_types_derive 0.0.1 (git+https://github.com/holochain/holochain-rust?branch=develop)",
+ "rmp 0.8.7 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rmp-serde 0.13.7 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.80 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_bytes 0.10.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_derive 1.0.80 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_json 1.0.33 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "holochain_net_ipc"
+version = "0.1.0"
+source = "git+https://github.com/holochain/holochain-rust?branch=develop#8e9da77855312dcf1c7134537332f12ff16313d6"
+dependencies = [
+ "failure 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "holochain_net_connection 0.1.0 (git+https://github.com/holochain/holochain-rust?branch=develop)",
+ "lazy_static 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rmp-serde 0.13.7 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.80 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_bytes 0.10.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_derive 1.0.80 (registry+https://github.com/rust-lang/crates.io-index)",
+ "zmq 0.8.2 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "holochain_wasm_utils"
 version = "0.0.1"
-source = "git+https://github.com/holochain/holochain-rust?branch=develop#1c726e7d5da5239131a781c24b1f6151b67cfefb"
+source = "git+https://github.com/holochain/holochain-rust?branch=develop#8e9da77855312dcf1c7134537332f12ff16313d6"
 dependencies = [
  "holochain_core_types 0.0.1 (git+https://github.com/holochain/holochain-rust?branch=develop)",
  "holochain_core_types_derive 0.0.1 (git+https://github.com/holochain/holochain-rust?branch=develop)",
  "serde 1.0.80 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_derive 1.0.80 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde_json 1.0.32 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_json 1.0.33 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -502,6 +542,14 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "log"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "log"
 version = "0.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
@@ -530,6 +578,16 @@ dependencies = [
 name = "memory_units"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "metadeps"
+version = "1.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "error-chain 0.10.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "pkg-config 0.3.14 (registry+https://github.com/rust-lang/crates.io-index)",
+ "toml 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
+]
 
 [[package]]
 name = "multihash"
@@ -615,9 +673,9 @@ version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "num-traits 0.2.6 (registry+https://github.com/rust-lang/crates.io-index)",
- "proc-macro2 0.4.20 (registry+https://github.com/rust-lang/crates.io-index)",
- "quote 0.6.9 (registry+https://github.com/rust-lang/crates.io-index)",
- "syn 0.15.18 (registry+https://github.com/rust-lang/crates.io-index)",
+ "proc-macro2 0.4.23 (registry+https://github.com/rust-lang/crates.io-index)",
+ "quote 0.6.10 (registry+https://github.com/rust-lang/crates.io-index)",
+ "syn 0.15.20 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -669,6 +727,11 @@ dependencies = [
 ]
 
 [[package]]
+name = "objekt"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
 name = "parity-wasm"
 version = "0.31.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -677,8 +740,13 @@ dependencies = [
 ]
 
 [[package]]
+name = "pkg-config"
+version = "0.3.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
 name = "proc-macro2"
-version = "0.4.20"
+version = "0.4.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "unicode-xid 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -686,10 +754,10 @@ dependencies = [
 
 [[package]]
 name = "quote"
-version = "0.6.9"
+version = "0.6.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "proc-macro2 0.4.20 (registry+https://github.com/rust-lang/crates.io-index)",
+ "proc-macro2 0.4.23 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -746,12 +814,12 @@ dependencies = [
 
 [[package]]
 name = "regex"
-version = "1.0.5"
+version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "aho-corasick 0.6.9 (registry+https://github.com/rust-lang/crates.io-index)",
  "memchr 2.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "regex-syntax 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "regex-syntax 0.6.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "thread_local 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "utf8-ranges 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -766,7 +834,7 @@ dependencies = [
 
 [[package]]
 name = "regex-syntax"
-version = "0.6.2"
+version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "ucd-util 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -868,6 +936,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "rmp"
+version = "0.8.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "byteorder 1.2.7 (registry+https://github.com/rust-lang/crates.io-index)",
+ "num-traits 0.1.43 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "rmp-serde"
+version = "0.13.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "byteorder 1.2.7 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rmp 0.8.7 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.80 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "runtime-fmt"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -887,7 +974,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "ryu"
-version = "0.2.6"
+version = "0.2.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -934,8 +1021,16 @@ dependencies = [
  "lazy_static 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)",
  "linked-hash-map 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "num-traits 0.1.43 (registry+https://github.com/rust-lang/crates.io-index)",
- "regex 1.0.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "regex 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 0.8.23 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "serde_bytes"
+version = "0.10.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "serde 1.0.80 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -943,19 +1038,19 @@ name = "serde_derive"
 version = "1.0.80"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "proc-macro2 0.4.20 (registry+https://github.com/rust-lang/crates.io-index)",
- "quote 0.6.9 (registry+https://github.com/rust-lang/crates.io-index)",
- "syn 0.15.18 (registry+https://github.com/rust-lang/crates.io-index)",
+ "proc-macro2 0.4.23 (registry+https://github.com/rust-lang/crates.io-index)",
+ "quote 0.6.10 (registry+https://github.com/rust-lang/crates.io-index)",
+ "syn 0.15.20 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "serde_json"
-version = "1.0.32"
+version = "1.0.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "indexmap 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "itoa 0.4.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "ryu 0.2.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "ryu 0.2.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.80 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -1001,18 +1096,18 @@ name = "syn"
 version = "0.14.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "proc-macro2 0.4.20 (registry+https://github.com/rust-lang/crates.io-index)",
- "quote 0.6.9 (registry+https://github.com/rust-lang/crates.io-index)",
+ "proc-macro2 0.4.23 (registry+https://github.com/rust-lang/crates.io-index)",
+ "quote 0.6.10 (registry+https://github.com/rust-lang/crates.io-index)",
  "unicode-xid 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "syn"
-version = "0.15.18"
+version = "0.15.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "proc-macro2 0.4.20 (registry+https://github.com/rust-lang/crates.io-index)",
- "quote 0.6.9 (registry+https://github.com/rust-lang/crates.io-index)",
+ "proc-macro2 0.4.23 (registry+https://github.com/rust-lang/crates.io-index)",
+ "quote 0.6.10 (registry+https://github.com/rust-lang/crates.io-index)",
  "unicode-xid 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -1021,9 +1116,9 @@ name = "synstructure"
 version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "proc-macro2 0.4.20 (registry+https://github.com/rust-lang/crates.io-index)",
- "quote 0.6.9 (registry+https://github.com/rust-lang/crates.io-index)",
- "syn 0.15.18 (registry+https://github.com/rust-lang/crates.io-index)",
+ "proc-macro2 0.4.23 (registry+https://github.com/rust-lang/crates.io-index)",
+ "quote 0.6.10 (registry+https://github.com/rust-lang/crates.io-index)",
+ "syn 0.15.20 (registry+https://github.com/rust-lang/crates.io-index)",
  "unicode-xid 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -1068,6 +1163,11 @@ dependencies = [
 
 [[package]]
 name = "toml"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "toml"
 version = "0.4.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
@@ -1109,13 +1209,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "uuid"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "rand 0.5.5 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "version_check"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "walkdir"
-version = "2.2.6"
+version = "2.2.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "same-file 1.0.4 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1174,6 +1282,25 @@ dependencies = [
  "linked-hash-map 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
+[[package]]
+name = "zmq"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "libc 0.2.43 (registry+https://github.com/rust-lang/crates.io-index)",
+ "log 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)",
+ "zmq-sys 0.8.2 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "zmq-sys"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "libc 0.2.43 (registry+https://github.com/rust-lang/crates.io-index)",
+ "metadeps 1.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
 [metadata]
 "checksum aho-corasick 0.6.9 (registry+https://github.com/rust-lang/crates.io-index)" = "1e9a933f4e58658d7b12defcf96dc5c720f20832deebe3e0a19efd3b6aaeeb9e"
 "checksum arrayref 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)" = "0d382e583f07208808f6b1249e60848879ba3543f57c32277bf52d69c2f0f0ee"
@@ -1182,6 +1309,7 @@ dependencies = [
 "checksum base64 0.9.3 (registry+https://github.com/rust-lang/crates.io-index)" = "489d6c0ed21b11d038c31b6ceccca973e65d73ba3bd8ecb9a2babf5546164643"
 "checksum bitflags 1.0.4 (registry+https://github.com/rust-lang/crates.io-index)" = "228047a76f468627ca71776ecdebd732a3423081fcf5125585bcd7c49886ce12"
 "checksum block-buffer 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)" = "a076c298b9ecdb530ed9d967e74a6027d6a7478924520acddcddc24c1c8ab3ab"
+"checksum boolinator 2.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "cfa8873f51c92e232f9bac4065cddef41b714152812bfc5f7672ba16d6ef8cd9"
 "checksum byte-tools 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "560c32574a12a89ecd91f5e742165893f86e3ab98d21f8ea548658eb9eef5f40"
 "checksum byteorder 1.2.7 (registry+https://github.com/rust-lang/crates.io-index)" = "94f88df23a25417badc922ab0f5716cc1330e87f71ddd9203b3a3ccd9cedf75d"
 "checksum bytes 0.4.10 (registry+https://github.com/rust-lang/crates.io-index)" = "0ce55bd354b095246fc34caf4e9e242f5297a7fd938b090cadfea6eee614aa62"
@@ -1194,6 +1322,7 @@ dependencies = [
 "checksum cslice 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "697c714f50560202b1f4e2e09cd50a421881c83e9025db75d15f276616f04f40"
 "checksum digest 0.7.6 (registry+https://github.com/rust-lang/crates.io-index)" = "03b072242a8cbaf9c145665af9d250c59af3b958f83ed6824e13533cf76d5b90"
 "checksum either 1.5.0 (registry+https://github.com/rust-lang/crates.io-index)" = "3be565ca5c557d7f59e7cfcf1844f9e3033650c929c6566f511e8005f205c1d0"
+"checksum error-chain 0.10.0 (registry+https://github.com/rust-lang/crates.io-index)" = "d9435d864e017c3c6afeac1654189b06cdb491cf2ff73dbf0d73b0f292f42ff8"
 "checksum failure 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)" = "6dd377bcc1b1b7ce911967e3ec24fa19c3224394ec05b54aa7b083d498341ac7"
 "checksum failure_derive 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)" = "64c2d913fe8ed3b6c6518eedf4538255b989945c14c2a7d5cbff62a5e2120596"
 "checksum fake-simd 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "e88a8acf291dafb59c2d96e8f59828f3838bb1a70398823ade51a84de6a6deed"
@@ -1212,14 +1341,15 @@ dependencies = [
 "checksum futures-util-preview 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "4b29aa737dba9e2e47a5dcd4d58ec7c7c2d5f78e8460f609f857bcf04163235e"
 "checksum gcc 0.3.55 (registry+https://github.com/rust-lang/crates.io-index)" = "8f5f3913fa0bfe7ee1fd8248b6b9f42a5af4b9d65ec2dd2c3c26132b950ecfc2"
 "checksum generic-array 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ef25c5683767570c2bbd7deba372926a55eaae9982d7726ee2a1050239d45b9d"
-"checksum holochain_agent 0.0.1 (git+https://github.com/holochain/holochain-rust?branch=develop)" = "<none>"
 "checksum holochain_cas_implementations 0.0.1 (git+https://github.com/holochain/holochain-rust?branch=develop)" = "<none>"
+"checksum holochain_container_api 0.0.1 (git+https://github.com/holochain/holochain-rust?branch=develop)" = "<none>"
 "checksum holochain_core 0.0.1 (git+https://github.com/holochain/holochain-rust?branch=develop)" = "<none>"
-"checksum holochain_core_api 0.0.1 (git+https://github.com/holochain/holochain-rust?branch=develop)" = "<none>"
 "checksum holochain_core_types 0.0.1 (git+https://github.com/holochain/holochain-rust?branch=develop)" = "<none>"
 "checksum holochain_core_types_derive 0.0.1 (git+https://github.com/holochain/holochain-rust?branch=develop)" = "<none>"
 "checksum holochain_dna 0.0.1 (git+https://github.com/holochain/holochain-rust?branch=develop)" = "<none>"
 "checksum holochain_net 0.0.1 (git+https://github.com/holochain/holochain-rust?branch=develop)" = "<none>"
+"checksum holochain_net_connection 0.1.0 (git+https://github.com/holochain/holochain-rust?branch=develop)" = "<none>"
+"checksum holochain_net_ipc 0.1.0 (git+https://github.com/holochain/holochain-rust?branch=develop)" = "<none>"
 "checksum holochain_wasm_utils 0.0.1 (git+https://github.com/holochain/holochain-rust?branch=develop)" = "<none>"
 "checksum indexmap 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)" = "7e81a7c05f79578dbc15793d8b619db9ba32b4577003ef3af1a91c416798c58d"
 "checksum iovec 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "dbe6e417e7d0975db6512b90796e8ce223145ac4e33c377e4a42882a0e88bb08"
@@ -1229,10 +1359,12 @@ dependencies = [
 "checksum libc 0.2.43 (registry+https://github.com/rust-lang/crates.io-index)" = "76e3a3ef172f1a0b9a9ff0dd1491ae5e6c948b94479a3021819ba7d860c8645d"
 "checksum linked-hash-map 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "6d262045c5b87c0861b3f004610afd0e2c851e2908d08b6c870cbb9d5f494ecd"
 "checksum linked-hash-map 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)" = "70fb39025bc7cdd76305867c4eccf2f2dcf6e9a57f5b21a93e1c2d86cd03ec9e"
+"checksum log 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)" = "e19e8d5c34a3e0e2223db8e060f9e8264aeeb5c5fc64a4ee9965c062211c024b"
 "checksum log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)" = "c84ec4b527950aa83a329754b01dbe3f58361d1c5efacd1f6d68c494d08a17c6"
 "checksum memchr 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)" = "148fab2e51b4f1cfc66da2a7c32981d1d3c083a803978268bb11fe4b86925e7a"
 "checksum memchr 2.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "0a3eb002f0535929f1199681417029ebea04aadc0c7a4224b46be99c7f5d6a16"
 "checksum memory_units 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "71d96e3f3c0b6325d8ccd83c33b28acb183edcb6c67938ba104ec546854b0882"
+"checksum metadeps 1.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "73b122901b3a675fac8cecf68dcb2f0d3036193bc861d1ac0e1c337f7d5254c2"
 "checksum multihash 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)" = "c62469025f45dee2464ef9fc845f4683c543993792c1993e7d903c17a4546b74"
 "checksum nan-preserving-float 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "34d4f00fcc2f4c9efa8cc971db0da9e28290e28e97af47585e48691ef10ff31f"
 "checksum neon 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "fd2e4dcd1e15c5944d89d283ec7c3b1b4ef83b5d2227b3b5d91d33224a45c7a3"
@@ -1249,18 +1381,20 @@ dependencies = [
 "checksum num-traits 0.1.43 (registry+https://github.com/rust-lang/crates.io-index)" = "92e5113e9fd4cc14ded8e499429f396a20f98c772a47cc8622a736e1ec843c31"
 "checksum num-traits 0.2.6 (registry+https://github.com/rust-lang/crates.io-index)" = "0b3a5d7cc97d6d30d8b9bc8fa19bf45349ffe46241e8816f50f62f6d6aaabee1"
 "checksum num_cpus 1.8.0 (registry+https://github.com/rust-lang/crates.io-index)" = "c51a3322e4bca9d212ad9a158a02abc6934d005490c054a2778df73a70aa0a30"
+"checksum objekt 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "7d32585b38ed56d6f37af8d99bca1025bced540f9b8926b1ed4953e00a2d39f4"
 "checksum parity-wasm 0.31.3 (registry+https://github.com/rust-lang/crates.io-index)" = "511379a8194230c2395d2f5fa627a5a7e108a9f976656ce723ae68fca4097bfc"
-"checksum proc-macro2 0.4.20 (registry+https://github.com/rust-lang/crates.io-index)" = "3d7b7eaaa90b4a90a932a9ea6666c95a389e424eff347f0f793979289429feee"
-"checksum quote 0.6.9 (registry+https://github.com/rust-lang/crates.io-index)" = "63b5829244f52738cfee93b3a165c1911388675be000c888d2fae620dee8fa5b"
+"checksum pkg-config 0.3.14 (registry+https://github.com/rust-lang/crates.io-index)" = "676e8eb2b1b4c9043511a9b7bea0915320d7e502b0a079fb03f9635a5252b18c"
+"checksum proc-macro2 0.4.23 (registry+https://github.com/rust-lang/crates.io-index)" = "88dae56b29da695d783ea7fc5a90de281f79eb38407e77f6d674dd8befc4ac47"
+"checksum quote 0.6.10 (registry+https://github.com/rust-lang/crates.io-index)" = "53fa22a1994bd0f9372d7a816207d8a2677ad0325b073f5c5332760f0fb62b5c"
 "checksum rand 0.4.3 (registry+https://github.com/rust-lang/crates.io-index)" = "8356f47b32624fef5b3301c1be97e5944ecdd595409cc5da11d05f211db6cfbd"
 "checksum rand 0.5.5 (registry+https://github.com/rust-lang/crates.io-index)" = "e464cd887e869cddcae8792a4ee31d23c7edd516700695608f5b98c67ee0131c"
 "checksum rand_core 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "1961a422c4d189dfb50ffa9320bf1f2a9bd54ecb92792fb9477f99a1045f3372"
 "checksum rand_core 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "0905b6b7079ec73b314d4c748701f6931eb79fd97c668caa3f1899b22b32c6db"
 "checksum redox_syscall 0.1.40 (registry+https://github.com/rust-lang/crates.io-index)" = "c214e91d3ecf43e9a4e41e578973adeb14b474f2bee858742d127af75a0112b1"
 "checksum regex 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)" = "9329abc99e39129fcceabd24cf5d85b4671ef7c29c50e972bc5afe32438ec384"
-"checksum regex 1.0.5 (registry+https://github.com/rust-lang/crates.io-index)" = "2069749032ea3ec200ca51e4a31df41759190a88edca0d2d86ee8bedf7073341"
+"checksum regex 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)" = "ee84f70c8c08744ea9641a731c7fadb475bf2ecc52d7f627feb833e0b3990467"
 "checksum regex-syntax 0.5.6 (registry+https://github.com/rust-lang/crates.io-index)" = "7d707a4fa2637f2dca2ef9fd02225ec7661fe01a53623c1e6515b6916511f7a7"
-"checksum regex-syntax 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)" = "747ba3b235651f6e2f67dfa8bcdcd073ddb7c243cb21c442fc12395dfcac212d"
+"checksum regex-syntax 0.6.3 (registry+https://github.com/rust-lang/crates.io-index)" = "fbc557aac2b708fe84121caf261346cc2eed71978024337e42eb46b8a252ac6e"
 "checksum remove_dir_all 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)" = "3488ba1b9a2084d38645c4c08276a1752dcbf2c7130d74f1569681ad5d2799c5"
 "checksum riker 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)" = "5865b6e51bcdb9822b370cbf8787198939c52e4e19ace274c5948df976ebbe35"
 "checksum riker-deadletter 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)" = "45a61980d4728761bdb319d66a58b506f2a161a14269221f08091b159c0ee351"
@@ -1270,10 +1404,12 @@ dependencies = [
 "checksum riker-mapvec 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)" = "a2caa965aad9b0ade8b7b68c7bd39027b6d9bff973631ca2784dc91e205c659a"
 "checksum riker-patterns 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)" = "74786a9e693fc98ea41490c6d6dad5e7a945cff26bad04536a4734ed2b8f8524"
 "checksum riker-timer 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)" = "779059c70a6c1592c58def63261e4b17affaa560a3802922df4c452b1c6a7020"
+"checksum rmp 0.8.7 (registry+https://github.com/rust-lang/crates.io-index)" = "a3d45d7afc9b132b34a2479648863aa95c5c88e98b32285326a6ebadc80ec5c9"
+"checksum rmp-serde 0.13.7 (registry+https://github.com/rust-lang/crates.io-index)" = "011e1d58446e9fa3af7cdc1fb91295b10621d3ac4cb3a85cc86385ee9ca50cd3"
 "checksum runtime-fmt 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "647a821d66049faccc993fc3c379d1181b81a484097495cda79ffdb17b55b87f"
 "checksum rust-base58 0.0.4 (registry+https://github.com/rust-lang/crates.io-index)" = "b313b91fcdc6719ad41fa2dad2b7e810b03833fae4bf911950e15529a5f04439"
 "checksum rustc-demangle 0.1.9 (registry+https://github.com/rust-lang/crates.io-index)" = "bcfe5b13211b4d78e5c2cadfebd7769197d95c639c35a50057eb4c05de811395"
-"checksum ryu 0.2.6 (registry+https://github.com/rust-lang/crates.io-index)" = "7153dd96dade874ab973e098cb62fcdbb89a03682e46b144fd09550998d4a4a7"
+"checksum ryu 0.2.7 (registry+https://github.com/rust-lang/crates.io-index)" = "eb9e9b8cde282a9fe6a42dd4681319bfb63f121b8a8ee9439c6f4107e58a46f7"
 "checksum safemem 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "8dca453248a96cb0749e36ccdfe2b0b4e54a61bfef89fb97ec621eb8e0a93dd9"
 "checksum same-file 1.0.4 (registry+https://github.com/rust-lang/crates.io-index)" = "8f20c4be53a8a1ff4c1f1b2bd14570d2f634628709752f0702ecdd2b3f9a5267"
 "checksum semver 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)" = "1d7eb9ef2c18661902cc47e535f9bc51b78acd254da71d375c2f6720d9a40403"
@@ -1281,20 +1417,22 @@ dependencies = [
 "checksum serde 0.8.23 (registry+https://github.com/rust-lang/crates.io-index)" = "9dad3f759919b92c3068c696c15c3d17238234498bbdcc80f2c469606f948ac8"
 "checksum serde 1.0.80 (registry+https://github.com/rust-lang/crates.io-index)" = "15c141fc7027dd265a47c090bf864cf62b42c4d228bbcf4e51a0c9e2b0d3f7ef"
 "checksum serde-hjson 0.8.2 (registry+https://github.com/rust-lang/crates.io-index)" = "0b833c5ad67d52ced5f5938b2980f32a9c1c5ef047f0b4fb3127e7a423c76153"
+"checksum serde_bytes 0.10.4 (registry+https://github.com/rust-lang/crates.io-index)" = "adb6e51a6b3696b301bc221d785f898b4457c619b51d7ce195a6d20baecb37b3"
 "checksum serde_derive 1.0.80 (registry+https://github.com/rust-lang/crates.io-index)" = "225de307c6302bec3898c51ca302fc94a7a1697ef0845fcee6448f33c032249c"
-"checksum serde_json 1.0.32 (registry+https://github.com/rust-lang/crates.io-index)" = "43344e7ce05d0d8280c5940cabb4964bea626aa58b1ec0e8c73fa2a8512a38ce"
+"checksum serde_json 1.0.33 (registry+https://github.com/rust-lang/crates.io-index)" = "c37ccd6be3ed1fdf419ee848f7c758eb31b054d7cd3ae3600e3bae0adf569811"
 "checksum serde_test 0.8.23 (registry+https://github.com/rust-lang/crates.io-index)" = "110b3dbdf8607ec493c22d5d947753282f3bae73c0f56d322af1e8c78e4c23d5"
 "checksum serde_test 1.0.80 (registry+https://github.com/rust-lang/crates.io-index)" = "55e94c89847cbce06c6919e006fc3c2da083ebefd491a233b40a6c9c42f53afe"
 "checksum sha1 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)" = "171698ce4ec7cbb93babeb3190021b4d72e96ccb98e33d277ae4ea959d6f2d9e"
 "checksum sha2 0.7.1 (registry+https://github.com/rust-lang/crates.io-index)" = "9eb6be24e4c23a84d7184280d2722f7f2731fcdd4a9d886efbfe4413e4847ea0"
 "checksum snowflake 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "27207bb65232eda1f588cf46db2fee75c0808d557f6b3cf19a75f5d6d7c94df1"
 "checksum syn 0.14.9 (registry+https://github.com/rust-lang/crates.io-index)" = "261ae9ecaa397c42b960649561949d69311f08eeaea86a65696e6e46517cf741"
-"checksum syn 0.15.18 (registry+https://github.com/rust-lang/crates.io-index)" = "90c39a061e2f412a9f869540471ab679e85e50c6b05604daf28bc3060f75c430"
+"checksum syn 0.15.20 (registry+https://github.com/rust-lang/crates.io-index)" = "8886c8d2774e853fcd7d9d2131f6e40ba46c9c0e358e4d57178452abd6859bb0"
 "checksum synstructure 0.10.1 (registry+https://github.com/rust-lang/crates.io-index)" = "73687139bf99285483c96ac0add482c3776528beac1d97d444f6e91f203a2015"
 "checksum tempfile 3.0.4 (registry+https://github.com/rust-lang/crates.io-index)" = "55c1195ef8513f3273d55ff59fe5da6940287a0d7a98331254397f464833675b"
 "checksum thread_local 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)" = "c6b53e329000edc2b34dbe8545fd20e55a333362d0a321909685a19bd28c3f1b"
 "checksum time 0.1.40 (registry+https://github.com/rust-lang/crates.io-index)" = "d825be0eb33fda1a7e68012d51e9c7f451dc1a69391e7fdc197060bb8c56667b"
 "checksum tiny-keccak 1.4.2 (registry+https://github.com/rust-lang/crates.io-index)" = "e9175261fbdb60781fcd388a4d6cc7e14764a2b629a7ad94abb439aed223a44f"
+"checksum toml 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "736b60249cb25337bc196faa43ee12c705e426f3d55c214d73a4e7be06f92cb4"
 "checksum toml 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)" = "4a2ecc31b0351ea18b3fe11274b8db6e4d82bce861bbb22e6dbed40417902c65"
 "checksum typenum 1.10.0 (registry+https://github.com/rust-lang/crates.io-index)" = "612d636f949607bdf9b123b4a6f6d966dedf3ff669f7f045890d3a4a73948169"
 "checksum ucd-util 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "d0f8bfa9ff0cadcd210129ad9d2c5f145c13e9ced3d3e5d948a6213487d52444"
@@ -1302,8 +1440,9 @@ dependencies = [
 "checksum unwrap_to 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "cad414b2eed757c1b6f810f8abc814e298a9c89176b21fae092c7a87756fb839"
 "checksum utf8-ranges 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)" = "796f7e48bef87609f7ade7e06495a87d5cd06c7866e6a5cbfceffc558a243737"
 "checksum uuid 0.6.5 (registry+https://github.com/rust-lang/crates.io-index)" = "e1436e58182935dcd9ce0add9ea0b558e8a87befe01c1a301e6020aeb0876363"
+"checksum uuid 0.7.1 (registry+https://github.com/rust-lang/crates.io-index)" = "dab5c5526c5caa3d106653401a267fed923e7046f35895ffcb5ca42db64942e6"
 "checksum version_check 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)" = "914b1a6776c4c929a602fafd8bc742e06365d4bcbe48c30f9cca5824f70dc9dd"
-"checksum walkdir 2.2.6 (registry+https://github.com/rust-lang/crates.io-index)" = "0ffb549f212c31e19f3667c55a7f515b983a84aef10fd0a4d1f9c125425115f3"
+"checksum walkdir 2.2.7 (registry+https://github.com/rust-lang/crates.io-index)" = "9d9d7ed3431229a144296213105a390676cc49c9b6a72bd19f3176c98e129fa1"
 "checksum wasmi 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "9b4a6d379e9332b1b1f52c5a87f2481c85c7c931d8ec411963dfb8f26b1ec1e3"
 "checksum winapi 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)" = "167dc9d6949a9b857f3451275e911c3f44255842c1f7a76f33c55103a909087a"
 "checksum winapi 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)" = "92c1eb33641e276cfa214a0522acad57be5c56b10cb348b3c5117db75f3ac4b0"
@@ -1311,3 +1450,5 @@ dependencies = [
 "checksum winapi-util 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "afc5508759c5bf4285e61feb862b6083c8480aec864fa17a81fdec6f69b461ab"
 "checksum winapi-x86_64-pc-windows-gnu 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 "checksum yaml-rust 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)" = "95acf0db5515d07da9965ec0e0ba6cc2d825e2caeb7303b66ca441729801254e"
+"checksum zmq 0.8.2 (registry+https://github.com/rust-lang/crates.io-index)" = "3e6e33f05ebc9a1cb360e5db1f8ed6e5512ece86aed271654b0f171d04c24c23"
+"checksum zmq-sys 0.8.2 (registry+https://github.com/rust-lang/crates.io-index)" = "c3cc251d25f3c6ffc54dfa3e8d808598825f8ccfee3a008dfc7866ffe325dcb3"

--- a/native/Cargo.lock
+++ b/native/Cargo.lock
@@ -326,7 +326,7 @@ dependencies = [
 [[package]]
 name = "holochain_cas_implementations"
 version = "0.0.1"
-source = "git+https://github.com/holochain/holochain-rust?branch=develop#8e9da77855312dcf1c7134537332f12ff16313d6"
+source = "git+https://github.com/holochain/holochain-rust?branch=develop#a853b4a6fd4ada1e1e0c0a31bf95e98d8ea06ae7"
 dependencies = [
  "futures-preview 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "holochain_core_types 0.0.1 (git+https://github.com/holochain/holochain-rust?branch=develop)",
@@ -348,7 +348,7 @@ dependencies = [
 [[package]]
 name = "holochain_container_api"
 version = "0.0.1"
-source = "git+https://github.com/holochain/holochain-rust?branch=develop#8e9da77855312dcf1c7134537332f12ff16313d6"
+source = "git+https://github.com/holochain/holochain-rust?branch=develop#a853b4a6fd4ada1e1e0c0a31bf95e98d8ea06ae7"
 dependencies = [
  "boolinator 2.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures-preview 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -365,7 +365,7 @@ dependencies = [
 [[package]]
 name = "holochain_core"
 version = "0.0.1"
-source = "git+https://github.com/holochain/holochain-rust?branch=develop#8e9da77855312dcf1c7134537332f12ff16313d6"
+source = "git+https://github.com/holochain/holochain-rust?branch=develop#a853b4a6fd4ada1e1e0c0a31bf95e98d8ea06ae7"
 dependencies = [
  "bitflags 1.0.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "chrono 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -395,7 +395,7 @@ dependencies = [
 [[package]]
 name = "holochain_core_types"
 version = "0.0.1"
-source = "git+https://github.com/holochain/holochain-rust?branch=develop#8e9da77855312dcf1c7134537332f12ff16313d6"
+source = "git+https://github.com/holochain/holochain-rust?branch=develop#a853b4a6fd4ada1e1e0c0a31bf95e98d8ea06ae7"
 dependencies = [
  "bitflags 1.0.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures-preview 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -413,7 +413,7 @@ dependencies = [
 [[package]]
 name = "holochain_core_types_derive"
 version = "0.0.1"
-source = "git+https://github.com/holochain/holochain-rust?branch=develop#8e9da77855312dcf1c7134537332f12ff16313d6"
+source = "git+https://github.com/holochain/holochain-rust?branch=develop#a853b4a6fd4ada1e1e0c0a31bf95e98d8ea06ae7"
 dependencies = [
  "quote 0.6.10 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.80 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -424,7 +424,7 @@ dependencies = [
 [[package]]
 name = "holochain_dna"
 version = "0.0.1"
-source = "git+https://github.com/holochain/holochain-rust?branch=develop#8e9da77855312dcf1c7134537332f12ff16313d6"
+source = "git+https://github.com/holochain/holochain-rust?branch=develop#a853b4a6fd4ada1e1e0c0a31bf95e98d8ea06ae7"
 dependencies = [
  "base64 0.9.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "holochain_core_types 0.0.1 (git+https://github.com/holochain/holochain-rust?branch=develop)",
@@ -438,7 +438,7 @@ dependencies = [
 [[package]]
 name = "holochain_net"
 version = "0.0.1"
-source = "git+https://github.com/holochain/holochain-rust?branch=develop#8e9da77855312dcf1c7134537332f12ff16313d6"
+source = "git+https://github.com/holochain/holochain-rust?branch=develop#a853b4a6fd4ada1e1e0c0a31bf95e98d8ea06ae7"
 dependencies = [
  "base64 0.9.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "failure 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -451,7 +451,7 @@ dependencies = [
 [[package]]
 name = "holochain_net_connection"
 version = "0.1.0"
-source = "git+https://github.com/holochain/holochain-rust?branch=develop#8e9da77855312dcf1c7134537332f12ff16313d6"
+source = "git+https://github.com/holochain/holochain-rust?branch=develop#a853b4a6fd4ada1e1e0c0a31bf95e98d8ea06ae7"
 dependencies = [
  "byteorder 1.2.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "failure 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -468,7 +468,7 @@ dependencies = [
 [[package]]
 name = "holochain_net_ipc"
 version = "0.1.0"
-source = "git+https://github.com/holochain/holochain-rust?branch=develop#8e9da77855312dcf1c7134537332f12ff16313d6"
+source = "git+https://github.com/holochain/holochain-rust?branch=develop#a853b4a6fd4ada1e1e0c0a31bf95e98d8ea06ae7"
 dependencies = [
  "failure 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "holochain_net_connection 0.1.0 (git+https://github.com/holochain/holochain-rust?branch=develop)",
@@ -483,7 +483,7 @@ dependencies = [
 [[package]]
 name = "holochain_wasm_utils"
 version = "0.0.1"
-source = "git+https://github.com/holochain/holochain-rust?branch=develop#8e9da77855312dcf1c7134537332f12ff16313d6"
+source = "git+https://github.com/holochain/holochain-rust?branch=develop#a853b4a6fd4ada1e1e0c0a31bf95e98d8ea06ae7"
 dependencies = [
  "holochain_core_types 0.0.1 (git+https://github.com/holochain/holochain-rust?branch=develop)",
  "holochain_core_types_derive 0.0.1 (git+https://github.com/holochain/holochain-rust?branch=develop)",

--- a/native/Cargo.toml
+++ b/native/Cargo.toml
@@ -15,10 +15,9 @@ neon-build = "0.2.0"
 
 [dependencies]
 neon = "0.2.0"
-holochain_core_api = { git = "https://github.com/holochain/holochain-rust", branch = "develop" }
+holochain_container_api = { git = "https://github.com/holochain/holochain-rust", branch = "develop" }
 holochain_core = { git = "https://github.com/holochain/holochain-rust", branch = "develop" }
 holochain_dna = { git = "https://github.com/holochain/holochain-rust", branch = "develop" }
-holochain_agent = { git = "https://github.com/holochain/holochain-rust", branch = "develop" }
 holochain_core_types = { git = "https://github.com/holochain/holochain-rust", branch = "develop" }
 holochain_cas_implementations = { git = "https://github.com/holochain/holochain-rust", branch = "develop" }
 tempfile="3"

--- a/native/Cargo.toml
+++ b/native/Cargo.toml
@@ -15,11 +15,11 @@ neon-build = "0.2.0"
 
 [dependencies]
 neon = "0.2.0"
-holochain_container_api = { git = "https://github.com/holochain/holochain-rust", branch = "develop" }
-holochain_core = { git = "https://github.com/holochain/holochain-rust", branch = "develop" }
-holochain_dna = { git = "https://github.com/holochain/holochain-rust", branch = "develop" }
-holochain_core_types = { git = "https://github.com/holochain/holochain-rust", branch = "develop" }
-holochain_cas_implementations = { git = "https://github.com/holochain/holochain-rust", branch = "develop" }
+holochain_container_api = { git = "https://github.com/holochain/holochain-rust", branch = "2018-11-15-make-refactor" }
+holochain_core = { git = "https://github.com/holochain/holochain-rust", branch = "2018-11-15-make-refactor" }
+holochain_dna = { git = "https://github.com/holochain/holochain-rust", branch = "2018-11-15-make-refactor" }
+holochain_core_types = { git = "https://github.com/holochain/holochain-rust", branch = "2018-11-15-make-refactor" }
+holochain_cas_implementations = { git = "https://github.com/holochain/holochain-rust", branch = "2018-11-15-make-refactor" }
 tempfile="3"
 
 base64 = "0.9"

--- a/native/Cargo.toml
+++ b/native/Cargo.toml
@@ -15,11 +15,11 @@ neon-build = "0.2.0"
 
 [dependencies]
 neon = "0.2.0"
-holochain_container_api = { git = "https://github.com/holochain/holochain-rust", branch = "net-ipc-zmq-test" }
-holochain_core = { git = "https://github.com/holochain/holochain-rust", branch = "net-ipc-zmq-test" }
-holochain_dna = { git = "https://github.com/holochain/holochain-rust", branch = "net-ipc-zmq-test" }
-holochain_core_types = { git = "https://github.com/holochain/holochain-rust", branch = "net-ipc-zmq-test" }
-holochain_cas_implementations = { git = "https://github.com/holochain/holochain-rust", branch = "net-ipc-zmq-test" }
+holochain_container_api = { git = "https://github.com/holochain/holochain-rust", branch = "develop" }
+holochain_core = { git = "https://github.com/holochain/holochain-rust", branch = "develop" }
+holochain_dna = { git = "https://github.com/holochain/holochain-rust", branch = "develop" }
+holochain_core_types = { git = "https://github.com/holochain/holochain-rust", branch = "develop" }
+holochain_cas_implementations = { git = "https://github.com/holochain/holochain-rust", branch = "develop" }
 tempfile="3"
 
 base64 = "0.9"

--- a/native/Cargo.toml
+++ b/native/Cargo.toml
@@ -15,11 +15,11 @@ neon-build = "0.2.0"
 
 [dependencies]
 neon = "0.2.0"
-holochain_container_api = { git = "https://github.com/holochain/holochain-rust", branch = "2018-11-15-make-refactor" }
-holochain_core = { git = "https://github.com/holochain/holochain-rust", branch = "2018-11-15-make-refactor" }
-holochain_dna = { git = "https://github.com/holochain/holochain-rust", branch = "2018-11-15-make-refactor" }
-holochain_core_types = { git = "https://github.com/holochain/holochain-rust", branch = "2018-11-15-make-refactor" }
-holochain_cas_implementations = { git = "https://github.com/holochain/holochain-rust", branch = "2018-11-15-make-refactor" }
+holochain_container_api = { git = "https://github.com/holochain/holochain-rust", branch = "net-ipc-zmq-test" }
+holochain_core = { git = "https://github.com/holochain/holochain-rust", branch = "net-ipc-zmq-test" }
+holochain_dna = { git = "https://github.com/holochain/holochain-rust", branch = "net-ipc-zmq-test" }
+holochain_core_types = { git = "https://github.com/holochain/holochain-rust", branch = "net-ipc-zmq-test" }
+holochain_cas_implementations = { git = "https://github.com/holochain/holochain-rust", branch = "net-ipc-zmq-test" }
 tempfile="3"
 
 base64 = "0.9"

--- a/native/src/app.rs
+++ b/native/src/app.rs
@@ -1,7 +1,7 @@
 use holochain_core::{
     context::Context as HolochainContext, logger::Logger, persister::SimplePersister,
 };
-use holochain_cas_implementations::{cas::file::FilesystemStorage, eav::file::EavFileStorage};
+use holochain_cas_implementations::{cas::memory::MemoryStorage, eav::memory::EavMemoryStorage};
 use holochain_container_api::Holochain;
 use holochain_dna::Dna;
 use holochain_core_types::{
@@ -38,8 +38,8 @@ declare_types! {
                 agent,
                 Arc::new(Mutex::new(NullLogger {})),
                 Arc::new(Mutex::new(SimplePersister::new("foo".to_string()))),
-                Arc::new(RwLock::new(FilesystemStorage::new(tempdir().unwrap().path().to_str().unwrap()).unwrap())),
-                Arc::new(RwLock::new(EavFileStorage::new(tempdir().unwrap().path().to_str().unwrap().to_string()).unwrap())),
+                Arc::new(RwLock::new(MemoryStorage::new().unwrap())),
+                Arc::new(RwLock::new(EavMemoryStorage::new().unwrap())),
             ).unwrap());
 
             let dna = Dna::try_from(JsonString::from(dna_data)).expect("unable to parse dna data");

--- a/native/src/app.rs
+++ b/native/src/app.rs
@@ -1,14 +1,16 @@
-use holochain_agent::Agent;
 use holochain_core::{
     context::Context as HolochainContext, logger::Logger, persister::SimplePersister,
 };
 use holochain_cas_implementations::{cas::file::FilesystemStorage, eav::file::EavFileStorage};
-use holochain_core_api::Holochain;
+use holochain_container_api::Holochain;
 use holochain_dna::Dna;
-use holochain_core_types::json::JsonString;
+use holochain_core_types::{
+    entry::agent::Agent,
+    json::JsonString
+};
 use neon::context::Context;
 use neon::prelude::*;
-use std::sync::{Arc, Mutex};
+use std::sync::{Arc, Mutex, RwLock};
 use tempfile::tempdir;
 use std::convert::TryFrom;
 
@@ -36,9 +38,8 @@ declare_types! {
                 agent,
                 Arc::new(Mutex::new(NullLogger {})),
                 Arc::new(Mutex::new(SimplePersister::new("foo".to_string()))),
-                FilesystemStorage::new(tempdir().unwrap().path().to_str().unwrap()).unwrap(),
-                EavFileStorage::new(tempdir().unwrap().path().to_str().unwrap().to_string())
-                        .unwrap(),
+                Arc::new(RwLock::new(FilesystemStorage::new(tempdir().unwrap().path().to_str().unwrap()).unwrap())),
+                Arc::new(RwLock::new(EavFileStorage::new(tempdir().unwrap().path().to_str().unwrap().to_string()).unwrap())),
             ).unwrap());
 
             let dna = Dna::try_from(JsonString::from(dna_data)).expect("unable to parse dna data");

--- a/native/src/lib.rs
+++ b/native/src/lib.rs
@@ -2,9 +2,8 @@
 #[macro_use]
 extern crate neon;
 extern crate base64;
-extern crate holochain_agent;
 extern crate holochain_core;
-extern crate holochain_core_api;
+extern crate holochain_container_api;
 extern crate holochain_core_types;
 extern crate holochain_dna;
 extern crate holochain_cas_implementations;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@holochain/holochain-nodejs",
-  "version": "0.1.12",
+  "version": "0.1.15",
   "description": "Node bindings for holochain",
   "main": "index.js",
   "author": "Julian Laubstein <contact@julianlaubstein.de>",


### PR DESCRIPTION
Fixes https://github.com/holochain/app-spec-rust/issues/40

* accommodated for changes in holochain-rust
* switched CAS from file storage to memory storage

We are planning to switch from hcshell to holochain-nodejs for testing, in the scope of DevCamp 2. The double instantiation problem occurs only when using the file implementation of the CAS. For tests, we don't want persistence anyway and since holochain-nodejs should only be used for tests I am switching this to memory storage here.

After this got merged and published to npm, we can switch app-spec-rust to work with holochain-nodejs, getting rid of the dependency to hcshell and thus reducing the complexity in the CI **a lot**.