### PR TITLE
Add windows builds, and templates to travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -55,7 +55,7 @@ jobs:
     env:
     - TRAVIS_NODE_VERSION="8"
     - SKIP_DEPLOY=0
-    if: tag =~ /^v\d+\.\d+\.\d+/ OR branch = master OR type = pull_request
+    if: tag =~ /^v\d+\.\d+\.\d+/ OR branch = add-windows-build OR type = pull_request
     install:
     - *install_unix_template
   - name: "OSX - Node 8"
@@ -63,7 +63,7 @@ jobs:
     env:
     - TRAVIS_NODE_VERSION="8"
     - SKIP_DEPLOY=0
-    if: tag =~ /^v\d+\.\d+\.\d+/ OR branch = master OR type = pull_request
+    if: tag =~ /^v\d+\.\d+\.\d+/ OR branch = add-windows-build OR type = pull_request
     install:
     - *install_unix_template
   - name: "Windows - Node 8"
@@ -75,7 +75,7 @@ jobs:
     - TRAVIS_NODE_VERSION="8"
     - SKIP_DEPLOY=0
     - LIBZMQ_PREFIX=C:\\Users\\travis\\build\\holochain\\holochain-nodejs\\holochain-rust\\vendor\\zmq
-    if: tag =~ /^v\d+\.\d+\.\d+/ OR branch = master OR type = pull_request
+    if: tag =~ /^v\d+\.\d+\.\d+/ OR branch = add-windows-build OR type = pull_request
     install:
     - *install_windows_template
   - name: "Linux - Node 10"
@@ -83,7 +83,7 @@ jobs:
     env:
     - TRAVIS_NODE_VERSION="10"
     - SKIP_DEPLOY=0
-    if: tag =~ /^v\d+\.\d+\.\d+/ OR branch = master OR type = pull_request
+    if: tag =~ /^v\d+\.\d+\.\d+/ OR branch = add-windows-build OR type = pull_request
     install:
     - *install_unix_template
   - name: "OSX - Node 10"
@@ -91,7 +91,7 @@ jobs:
     env:
     - TRAVIS_NODE_VERSION="10"
     - SKIP_DEPLOY=0
-    if: tag =~ /^v\d+\.\d+\.\d+/ OR branch = master OR type = pull_request
+    if: tag =~ /^v\d+\.\d+\.\d+/ OR branch = add-windows-build OR type = pull_request
     install:
     - *install_unix_template
   - name: "Windows - Node 10"
@@ -103,7 +103,7 @@ jobs:
     - TRAVIS_NODE_VERSION="10"
     - SKIP_DEPLOY=0
     - LIBZMQ_PREFIX=C:\\Users\\travis\\build\\holochain\\holochain-nodejs\\holochain-rust\\vendor\\zmq
-    if: tag =~ /^v\d+\.\d+\.\d+/ OR branch = master OR type = pull_request
+    if: tag =~ /^v\d+\.\d+\.\d+/ OR branch = add-windows-build OR type = pull_request
     install:
     - *install_windows_template
   - name: "Linux - Node 11"
@@ -111,7 +111,7 @@ jobs:
     env:
     - TRAVIS_NODE_VERSION="11"
     - SKIP_DEPLOY=0
-    if: tag =~ /^v\d+\.\d+\.\d+/ OR branch = master OR type = pull_request
+    if: tag =~ /^v\d+\.\d+\.\d+/ OR branch = add-windows-build OR type = pull_request
     install:
     - *install_unix_template
   - name: "OSX - Node 11"
@@ -119,9 +119,9 @@ jobs:
     env:
     - TRAVIS_NODE_VERSION="11"
     - SKIP_DEPLOY=0
-    if: tag =~ /^v\d+\.\d+\.\d+/ OR branch = master OR type = pull_request
+    if: tag =~ /^v\d+\.\d+\.\d+/ OR branch = add-windows-build OR type = pull_request
     install:
-    - *install_unix_template
+    - <<: *install_unix_template
   - name: "Windows - Node 11"
     os: windows
     rust:
@@ -131,9 +131,9 @@ jobs:
     - TRAVIS_NODE_VERSION="11"
     - SKIP_DEPLOY=0
     - LIBZMQ_PREFIX=C:\\Users\\travis\\build\\holochain\\holochain-nodejs\\holochain-rust\\vendor\\zmq
-    if: tag =~ /^v\d+\.\d+\.\d+/ OR branch = master OR type = pull_request
+    if: tag =~ /^v\d+\.\d+\.\d+/ OR branch = add-windows-build OR type = pull_request
     install:
-    - *install_windows_template
+    - <<: *install_windows_template
   
 
   # NOTE

--- a/.travis.yml
+++ b/.travis.yml
@@ -56,63 +56,63 @@ jobs:
     env:
     - TRAVIS_NODE_VERSION="8"
     - SKIP_DEPLOY=0
-    if: tag =~ /^v\d+\.\d+\.\d+/ OR branch = add-windows-build OR type = pull_request
+    if: tag =~ /^v\d+\.\d+\.\d+/ OR branch = master OR type = pull_request
   - <<: *_install_unix_template
     name: "OSX - Node 8"
     os: osx
     env:
     - TRAVIS_NODE_VERSION="8"
     - SKIP_DEPLOY=0
-    if: tag =~ /^v\d+\.\d+\.\d+/ OR branch = add-windows-build OR type = pull_request
+    if: tag =~ /^v\d+\.\d+\.\d+/ OR branch = master OR type = pull_request
   - <<: *_install_windows_template
     name: "Windows - Node 8"
     env:
     - TRAVIS_NODE_VERSION="8"
     - SKIP_DEPLOY=0
     - LIBZMQ_PREFIX=C:\\Users\\travis\\build\\holochain\\holochain-nodejs\\holochain-rust\\vendor\\zmq
-    if: tag =~ /^v\d+\.\d+\.\d+/ OR branch = add-windows-build OR type = pull_request
+    if: tag =~ /^v\d+\.\d+\.\d+/ OR branch = master OR type = pull_request
   - <<: *_install_unix_template
     name: "Linux - Node 10"
     os: linux
     env:
     - TRAVIS_NODE_VERSION="10"
     - SKIP_DEPLOY=0
-    if: tag =~ /^v\d+\.\d+\.\d+/ OR branch = add-windows-build OR type = pull_request
+    if: tag =~ /^v\d+\.\d+\.\d+/ OR branch = master OR type = pull_request
   - <<: *_install_unix_template
     name: "OSX - Node 10"
     os: osx
     env:
     - TRAVIS_NODE_VERSION="10"
     - SKIP_DEPLOY=0
-    if: tag =~ /^v\d+\.\d+\.\d+/ OR branch = add-windows-build OR type = pull_request
+    if: tag =~ /^v\d+\.\d+\.\d+/ OR branch = master OR type = pull_request
   - <<: *_install_windows_template
     name: "Windows - Node 10"
     env:
     - TRAVIS_NODE_VERSION="10"
     - SKIP_DEPLOY=0
     - LIBZMQ_PREFIX=C:\\Users\\travis\\build\\holochain\\holochain-nodejs\\holochain-rust\\vendor\\zmq
-    if: tag =~ /^v\d+\.\d+\.\d+/ OR branch = add-windows-build OR type = pull_request
+    if: tag =~ /^v\d+\.\d+\.\d+/ OR branch = master OR type = pull_request
   - <<: *_install_unix_template
     name: "Linux - Node 11"
     os: linux
     env:
     - TRAVIS_NODE_VERSION="11"
     - SKIP_DEPLOY=0
-    if: tag =~ /^v\d+\.\d+\.\d+/ OR branch = add-windows-build OR type = pull_request
+    if: tag =~ /^v\d+\.\d+\.\d+/ OR branch = master OR type = pull_request
   - <<: *_install_unix_template
     name: "OSX - Node 11"
     os: osx
     env:
     - TRAVIS_NODE_VERSION="11"
     - SKIP_DEPLOY=0
-    if: tag =~ /^v\d+\.\d+\.\d+/ OR branch = add-windows-build OR type = pull_request
+    if: tag =~ /^v\d+\.\d+\.\d+/ OR branch = master OR type = pull_request
   - <<: *_install_windows_template
     name: "Windows - Node 11"
     env:
     - TRAVIS_NODE_VERSION="11"
     - SKIP_DEPLOY=0
     - LIBZMQ_PREFIX=C:\\Users\\travis\\build\\holochain\\holochain-nodejs\\holochain-rust\\vendor\\zmq
-    if: tag =~ /^v\d+\.\d+\.\d+/ OR branch = add-windows-build OR type = pull_request
+    if: tag =~ /^v\d+\.\d+\.\d+/ OR branch = master OR type = pull_request
 
   # NOTE
   # the following is all commented out because windows travis

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,45 +1,185 @@
-sudo: false
+sudo: true
 language: rust
 rust:
-  - nightly-2018-10-12-x86_64-pc-windows-msvc
+- nightly
 
+# all unlabeled jobs run at test. Only if all "test" jobs finish, will the publish job run
 stages:
   - test
   - publish
 
-jobs:
-  include:
-  - name: "Windows - Node 8"
-    os: windows
-    env:
-    - RUST_BACKTRACE=1
-    - TRAVIS_NODE_VERSION="10"
-    - SKIP_DEPLOY=0
-    - LIBZMQ_PREFIX=C:\\Users\\travis\\build\\holochain\\holochain-nodejs\\holochain-rust\\vendor\\zmq
-    # if: tag =~ /^v\d+\.\d+\.\d+/ OR branch = master OR type = pull_request
+_install_unix_template: &_install_unix_template
+  # configuration borrowed from holochain-rust Makefile, showing how to install zmq for ubuntu trusty on travis
+  - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then
+      echo "deb http://download.opensuse.org/repositories/network:/messaging:/zeromq:/release-stable/xUbuntu_14.04/ ./" >> /etc/apt/sources.list;
+      wget https://download.opensuse.org/repositories/network:/messaging:/zeromq:/release-stable/xUbuntu_14.04/Release.key -O- | sudo apt-key add;
+      sudo apt-get update -qq;
+      sudo apt-get install libzmq3-dev;
+    fi
+  - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew install zmq; fi
 
-before_install:
+  # install our own nodejs to get a reasonable version
+  - rm -rf ~/.nvm && git clone https://github.com/creationix/nvm.git ~/.nvm && (cd ~/.nvm && git checkout `git describe --abbrev=0 --tags`) && source ~/.nvm/nvm.sh && nvm install $TRAVIS_NODE_VERSION
+  
+  # install our own yarn to make things work on osx
+  - curl -o- -L https://yarnpkg.com/install.sh | bash -s -- --version 1.10.1
+  - export PATH=$HOME/.yarn/bin:$PATH
+
+_install_windows_template: &_install_windows_template
   - choco install nodist
   - choco upgrade yarn
   - export PATH="/c/Program Files (x86)/Yarn/bin:/c/Program Files (x86)/Nodist/bin:$PATH"
-
-install:
   - export NODE_PATH="/c/Program Files (x86)\Nodist\bin\node_modules;$NODE_PATH"
   - export NODIST_PREFIX="/c/Program Files (x86)\Nodist"
   - export NODIST_X64=1
   - nodist add $TRAVIS_NODE_VERSION
   - nodist $TRAVIS_NODE_VERSION
   - node -e "console.log(process.argv[0], process.arch, process.versions)"
-  - rustup component add rustfmt-preview
   # bring in holochain-rust for prebuilt 4.1 zmq binary
   - git clone https://github.com/holochain/holochain-rust.git
-  - yarn install --ignore-scripts
-  - npm install --scripts-prepend-node-path=true --global --vs2015 --production windows-build-tools
+  - export PATH=$PATH:/c/Users/travis/build/holochain/holochain-nodejs/holochain-rust/vendor/zmq/bin  
   # deps for neon, found at https://guides.neon-bindings.com/getting-started/
+  - npm install --scripts-prepend-node-path=true --global --vs2015 --production windows-build-tools
   - yarn config set python python2.7
   - npm config set msvs_version 2015
   - yarn config set msvs_version 2015 --global
+  
 
+jobs:
+  include:
+
+  # PRs, pushes to master, and tags build on all target arches
+  # if this is release tag, the resultant binary will be uploaded to github
+  - name: "Linux - Node 8"
+    os: linux
+    env:
+    - TRAVIS_NODE_VERSION="8"
+    - SKIP_DEPLOY=0
+    if: tag =~ /^v\d+\.\d+\.\d+/ OR branch = master OR type = pull_request
+    install:
+    - <<: *install_unix_template
+  - name: "OSX - Node 8"
+    os: osx
+    env:
+    - TRAVIS_NODE_VERSION="8"
+    - SKIP_DEPLOY=0
+    if: tag =~ /^v\d+\.\d+\.\d+/ OR branch = master OR type = pull_request
+    install:
+    - <<: *install_unix_template
+  - name: "Windows - Node 8"
+    os: windows
+    rust:
+    # match the rust windows nightly version from holochain-rust
+    - nightly-2018-10-12-x86_64-pc-windows-msvc
+    env:
+    - TRAVIS_NODE_VERSION="8"
+    - SKIP_DEPLOY=0
+    - LIBZMQ_PREFIX=C:\\Users\\travis\\build\\holochain\\holochain-nodejs\\holochain-rust\\vendor\\zmq
+    if: tag =~ /^v\d+\.\d+\.\d+/ OR branch = master OR type = pull_request
+    install:
+    - <<: *install_windows_template
+  - name: "Linux - Node 10"
+    os: linux
+    env:
+    - TRAVIS_NODE_VERSION="10"
+    - SKIP_DEPLOY=0
+    if: tag =~ /^v\d+\.\d+\.\d+/ OR branch = master OR type = pull_request
+    install:
+    - <<: *install_unix_template
+  - name: "OSX - Node 10"
+    os: osx
+    env:
+    - TRAVIS_NODE_VERSION="10"
+    - SKIP_DEPLOY=0
+    if: tag =~ /^v\d+\.\d+\.\d+/ OR branch = master OR type = pull_request
+    install:
+    - <<: *install_unix_template
+  - name: "Windows - Node 10"
+    os: windows
+    rust:
+    # match the rust windows nightly version from holochain-rust
+    - nightly-2018-10-12-x86_64-pc-windows-msvc
+    env:
+    - TRAVIS_NODE_VERSION="10"
+    - SKIP_DEPLOY=0
+    - LIBZMQ_PREFIX=C:\\Users\\travis\\build\\holochain\\holochain-nodejs\\holochain-rust\\vendor\\zmq
+    if: tag =~ /^v\d+\.\d+\.\d+/ OR branch = master OR type = pull_request
+    install:
+    - <<: *install_windows_template
+  - name: "Linux - Node 11"
+    os: linux
+    env:
+    - TRAVIS_NODE_VERSION="11"
+    - SKIP_DEPLOY=0
+    if: tag =~ /^v\d+\.\d+\.\d+/ OR branch = master OR type = pull_request
+    install:
+    - <<: *install_unix_template
+  - name: "OSX - Node 11"
+    os: osx
+    env:
+    - TRAVIS_NODE_VERSION="11"
+    - SKIP_DEPLOY=0
+    if: tag =~ /^v\d+\.\d+\.\d+/ OR branch = master OR type = pull_request
+    install:
+    - <<: *install_unix_template
+  - name: "Windows - Node 11"
+    os: windows
+    rust:
+    # match the rust windows nightly version from holochain-rust
+    - nightly-2018-10-12-x86_64-pc-windows-msvc
+    env:
+    - TRAVIS_NODE_VERSION="11"
+    - SKIP_DEPLOY=0
+    - LIBZMQ_PREFIX=C:\\Users\\travis\\build\\holochain\\holochain-nodejs\\holochain-rust\\vendor\\zmq
+    if: tag =~ /^v\d+\.\d+\.\d+/ OR branch = master OR type = pull_request
+    install:
+    - <<: *install_windows_template
+  
+
+  # NOTE
+  # the following is all commented out because windows travis
+  # breaks (for now) with the use of secure environment variables
+  # so for now we are choosing the release/deploy builds
+  # over the automated publishing to NPM which we can easily do
+  # -----
+  # Publish to npm only on release tag
+  # - stage: publish
+  #   name: "Publish to npm"
+  #   os: linux
+  #   env: 
+  #     - TRAVIS_NODE_VERSION="8"
+  #     - SKIP_DEPLOY=1
+      
+  #   if: tag =~ /^v\d+\.\d+\.\d+/
+  #   before_install:
+  #     - npm config set //registry.npmjs.org/:_authToken=$NPM_TOKEN
+  #   script: 
+  #     - echo "Deploying to NPM..."
+  #     - node publish.js --publish
+
+# all of this can be common between windows and unix
+cache:
+    yarn: true
+    cargo: true
+    directories:
+        - node_modules
+before_script:
+    - rustup component add rustfmt-preview
+    - yarn install --ignore-scripts
 script:
-  - PATH=$PATH:/c/Users/travis/build/holochain/holochain-nodejs/holochain-rust/vendor/zmq/bin
-  - node publish.js
+    - node publish.js
+
+# deploy the node-pre-gyp binary to github releases so it's there when the npm package is installed
+deploy:
+    provider: releases
+    api_key:
+        secure: RmlFk4bed1I8pRV9cEihHx6gKtJT8KqSHTLXh6usut87MTLz3Nbil6sYwG8gI+MJjy5Q5ScoACgpyQHGX7W/eSvmP2te878TecppHPAlF1JfM3O9jYMahS8ME6+HwtTEZBkdIVvJMFgCHbL13Q2utN09BcOHM9316ftce2rGz8vL/utBgzR7WY7gKeeJhPBKMyYti355Oeks4Ig2E8ELC5JP3yiuLwbqmahTbk4kXWEkzsXHHBj/uGtMFpqQ7DMfTls8pjDbagqHbswSLQ6rZfiWmt/IJdO/tGPPqD7eYAnI/uA1uHaQOOK5exwS9VsKZvOmDj/xFaLDRPEnPhDLOY7ei+NdSN2GODmIaytQg5RYBPkSX9E5mVD9bB5xIU5tu43fPMd6TcurH6OxfzbhAVza4YSII0pcu4C+v852NDiUbIFmQ93ns1YnRpql9ajZR62WhqcJucJc/PedEGd/4wF/DsBjBIHgAjReBnLdBPagi4HgE8YbBeXJK9zebZjRt0gIp45tb1MocxHO0ywz/qiYYFjYdCeF80b0WsoLb5sw5Rta7pzwVcRETNhJ//mnw3Ws0pCu7H5gHuwtnXjDaHxK5y/lll14XatHTCWA0wRBi45iAoJKYKStzB+QS7F2biIEwaBBR0OoeFCOZu1zQy0lTtwhYQ0zth1jr8usPtU=
+    file_glob: true
+    file: bin-package/*.tar.gz
+    skip_cleanup: true
+
+    # publish only if we're building a tag and if the SKIP_DEPLOY is set to 0
+    on:
+        tags: true
+        condition: $SKIP_DEPLOY = 0
+    name: Version $TRAVIS_TAG

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,10 +18,8 @@ _install_unix_template: &_install_unix_template
       sudo apt-get install libzmq3-dev;
     fi
   - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew install zmq; fi
-
   # install our own nodejs to get a reasonable version
   - rm -rf ~/.nvm && git clone https://github.com/creationix/nvm.git ~/.nvm && (cd ~/.nvm && git checkout `git describe --abbrev=0 --tags`) && source ~/.nvm/nvm.sh && nvm install $TRAVIS_NODE_VERSION
-  
   # install our own yarn to make things work on osx
   - curl -o- -L https://yarnpkg.com/install.sh | bash -s -- --version 1.10.1
   - export PATH=$HOME/.yarn/bin:$PATH
@@ -45,27 +43,26 @@ _install_windows_template: &_install_windows_template
   - yarn config set python python2.7
   - npm config set msvs_version 2015
   - yarn config set msvs_version 2015 --global
-  
 
 jobs:
   include:
   # PRs, pushes to master, and tags build on all target arches
   # if this is release tag, the resultant binary will be uploaded to github
-  - <<: *install_unix_template
+  - <<: *_install_unix_template
     name: "Linux - Node 8"
     os: linux
     env:
     - TRAVIS_NODE_VERSION="8"
     - SKIP_DEPLOY=0
     if: tag =~ /^v\d+\.\d+\.\d+/ OR branch = add-windows-build OR type = pull_request
-  - <<: *install_unix_template
+  - <<: *_install_unix_template
     name: "OSX - Node 8"
     os: osx
     env:
     - TRAVIS_NODE_VERSION="8"
     - SKIP_DEPLOY=0
     if: tag =~ /^v\d+\.\d+\.\d+/ OR branch = add-windows-build OR type = pull_request
-  - <<: *install_windows_template
+  - <<: *_install_windows_template
     name: "Windows - Node 8"
     os: windows
     rust:
@@ -76,21 +73,21 @@ jobs:
     - SKIP_DEPLOY=0
     - LIBZMQ_PREFIX=C:\\Users\\travis\\build\\holochain\\holochain-nodejs\\holochain-rust\\vendor\\zmq
     if: tag =~ /^v\d+\.\d+\.\d+/ OR branch = add-windows-build OR type = pull_request
-  - <<: *install_unix_template
+  - <<: *_install_unix_template
     name: "Linux - Node 10"
     os: linux
     env:
     - TRAVIS_NODE_VERSION="10"
     - SKIP_DEPLOY=0
     if: tag =~ /^v\d+\.\d+\.\d+/ OR branch = add-windows-build OR type = pull_request
-  - <<: *install_unix_template
+  - <<: *_install_unix_template
     name: "OSX - Node 10"
     os: osx
     env:
     - TRAVIS_NODE_VERSION="10"
     - SKIP_DEPLOY=0
     if: tag =~ /^v\d+\.\d+\.\d+/ OR branch = add-windows-build OR type = pull_request
-  - <<: *install_windows_template
+  - <<: *_install_windows_template
     name: "Windows - Node 10"
     os: windows
     rust:
@@ -101,21 +98,21 @@ jobs:
     - SKIP_DEPLOY=0
     - LIBZMQ_PREFIX=C:\\Users\\travis\\build\\holochain\\holochain-nodejs\\holochain-rust\\vendor\\zmq
     if: tag =~ /^v\d+\.\d+\.\d+/ OR branch = add-windows-build OR type = pull_request
-  - <<: *install_unix_template
+  - <<: *_install_unix_template
     name: "Linux - Node 11"
     os: linux
     env:
     - TRAVIS_NODE_VERSION="11"
     - SKIP_DEPLOY=0
     if: tag =~ /^v\d+\.\d+\.\d+/ OR branch = add-windows-build OR type = pull_request
-  - <<: *install_unix_template
+  - <<: *_install_unix_template
     name: "OSX - Node 11"
     os: osx
     env:
     - TRAVIS_NODE_VERSION="11"
     - SKIP_DEPLOY=0
     if: tag =~ /^v\d+\.\d+\.\d+/ OR branch = add-windows-build OR type = pull_request
-  - <<: *install_windows_template
+  - <<: *_install_windows_template
     name: "Windows - Node 11"
     os: windows
     rust:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,3 @@
-# all unlabeled jobs run at test. Only if all "test" jobs finish, will the publish job run
-stages:
-  - test
-  - publish
-
 jobs:
   include:
   - name: "Windows - Node 8"

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,7 +16,7 @@ jobs:
     - TRAVIS_NODE_VERSION="10"
     - SKIP_DEPLOY=0
     - LIBZMQ_PREFIX=C:\\Users\\travis\\build\\holochain\\holochain-nodejs\\holochain-rust\\vendor\\zmq
-    if: tag =~ /^v\d+\.\d+\.\d+/ OR branch = master OR type = pull_request
+    # if: tag =~ /^v\d+\.\d+\.\d+/ OR branch = master OR type = pull_request
 
 before_install:
   - choco install nodist

--- a/.travis.yml
+++ b/.travis.yml
@@ -64,9 +64,11 @@ jobs:
   #     - echo "Deploying to NPM..."
   #     - node publish.js --publish
 
-install:
+before_install:
   - choco install nodist
   - choco install yarn
+
+install:
   - nodist add $TRAVIS_NODE_VERSION
   - nodist $TRAVIS_NODE_VERSION
   # configuration borrowed from holochain-rust Makefile, showing how to install zmq for ubuntu trusty on travis

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,3 @@
-sudo: true
-language: rust
-rust:
-- nightly
-
 # all unlabeled jobs run at test. Only if all "test" jobs finish, will the publish job run
 stages:
   - test
@@ -10,108 +5,39 @@ stages:
 
 jobs:
   include:
-
-  # PRs, pushes to master, and tags build on all target arches
-  # if this is release tag, the resultant binary will be uploaded to github
-  # - name: "Linux - Node 8"
-  #   os: linux
-  #   env:
-  #   - TRAVIS_NODE_VERSION="8"
-  #   - SKIP_DEPLOY=0
-  #   if: tag =~ /^v\d+\.\d+\.\d+/ OR branch = master OR type = pull_request
-
-  # - name: "OSX - Node 8"
-  #   os: osx
-  #   env:
-  #   - TRAVIS_NODE_VERSION="8"
-  #   - SKIP_DEPLOY=0
-  #   if: tag =~ /^v\d+\.\d+\.\d+/ OR branch = master OR type = pull_request
-
-  # - name: "Linux - Node 10"
-  #   os: linux
-  #   env:
-  #   - TRAVIS_NODE_VERSION="10"
-  #   - SKIP_DEPLOY=0
-  #   if: tag =~ /^v\d+\.\d+\.\d+/ OR branch = master OR type = pull_request
-
-  # - name: "OSX - Node 10"
-  #   os: osx
-  #   env:
-  #   - TRAVIS_NODE_VERSION="10"
-  #   - SKIP_DEPLOY=0
-  #   if: tag =~ /^v\d+\.\d+\.\d+/ OR branch = master OR type = pull_request
-
   - name: "Windows - Node 8"
+    sudo: true
+    language: rust
+    rust: nightly-2018-10-12-x86_64-pc-windows-msvc
     os: windows
     env:
-    - TRAVIS_NODE_VERSION="8"
+    - RUST_BACKTRACE=1
+    - TRAVIS_NODE_VERSION="10"
     - SKIP_DEPLOY=0
+    - LIBZMQ_PREFIX=C:\\Users\\travis\\build\\Connoropolous\\holochain-nodejs\\holochain-rust\\vendor\\zmq
     if: tag =~ /^v\d+\.\d+\.\d+/ OR branch = master OR type = pull_request
-
-  # 
-  # # Publish to npm only on release tag
-  # - stage: publish
-  #   name: "Publish to npm"
-  #   os: linux
-  #   env: 
-  #     - TRAVIS_NODE_VERSION="8"
-  #     - SKIP_DEPLOY=1
-      
-  #   if: tag =~ /^v\d+\.\d+\.\d+/
-  #   before_install:
-  #     - npm config set //registry.npmjs.org/:_authToken=$NPM_TOKEN
-  #   script: 
-  #     - echo "Deploying to NPM..."
-  #     - node publish.js --publish
-
-install:
-  - choco install nodist
-  - choco install yarn
-  - Install-ChocolateyPath -PathToInstall "C:\ProgramData\Chocolatey\nodist"
-  - Install-ChocolateyPath -PathToInstall "C:\ProgramData\Chocolatey\yarn"
-  - refreshenv
-  - nodist add $TRAVIS_NODE_VERSION
-  - nodist $TRAVIS_NODE_VERSION
-  # configuration borrowed from holochain-rust Makefile, showing how to install zmq for ubuntu trusty on travis
-  # - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then
-  #     echo "deb http://download.opensuse.org/repositories/network:/messaging:/zeromq:/release-stable/xUbuntu_14.04/ ./" >> /etc/apt/sources.list;
-  #     wget https://download.opensuse.org/repositories/network:/messaging:/zeromq:/release-stable/xUbuntu_14.04/Release.key -O- | sudo apt-key add;
-  #     sudo apt-get update -qq;
-  #     sudo apt-get install libzmq3-dev;
-  #   fi
-  # - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew install zmq; fi
-
-  # # install our own nodejs to get a reasonable version
-  # - rm -rf ~/.nvm && git clone https://github.com/creationix/nvm.git ~/.nvm && (cd ~/.nvm && git checkout `git describe --abbrev=0 --tags`) && source ~/.nvm/nvm.sh && nvm install $TRAVIS_NODE_VERSION
-  
-  # install our own nodejs to get a reasonable version
-  # - rm -rf ~/.nvm && git clone https://github.com/creationix/nvm.git ~/.nvm && (cd ~/.nvm && git checkout `git describe --abbrev=0 --tags`) && source ~/.nvm/nvm.sh && nvm install $TRAVIS_NODE_VERSION
-  # install our own yarn to make things work on osx
-  # - curl -o- -L https://yarnpkg.com/install.sh | bash -s -- --version 1.10.1
-  # - export PATH=$HOME/.yarn/bin:$PATH
-
-cache:
-    yarn: true
-    cargo: true
-    directories:
-        - node_modules
-before_script:
-    - rustup component add rustfmt-preview
-    - yarn install --ignore-scripts
-script:
-    # - pushd native/ && cargo fmt -- --check && popd
-    - node publish.js
-
-# deploy the node-pre-gyp binary to github releases so it's there when the npm package is installed
-# deploy:
-#     provider: releases
-#     api_key:
-#         secure: RmlFk4bed1I8pRV9cEihHx6gKtJT8KqSHTLXh6usut87MTLz3Nbil6sYwG8gI+MJjy5Q5ScoACgpyQHGX7W/eSvmP2te878TecppHPAlF1JfM3O9jYMahS8ME6+HwtTEZBkdIVvJMFgCHbL13Q2utN09BcOHM9316ftce2rGz8vL/utBgzR7WY7gKeeJhPBKMyYti355Oeks4Ig2E8ELC5JP3yiuLwbqmahTbk4kXWEkzsXHHBj/uGtMFpqQ7DMfTls8pjDbagqHbswSLQ6rZfiWmt/IJdO/tGPPqD7eYAnI/uA1uHaQOOK5exwS9VsKZvOmDj/xFaLDRPEnPhDLOY7ei+NdSN2GODmIaytQg5RYBPkSX9E5mVD9bB5xIU5tu43fPMd6TcurH6OxfzbhAVza4YSII0pcu4C+v852NDiUbIFmQ93ns1YnRpql9ajZR62WhqcJucJc/PedEGd/4wF/DsBjBIHgAjReBnLdBPagi4HgE8YbBeXJK9zebZjRt0gIp45tb1MocxHO0ywz/qiYYFjYdCeF80b0WsoLb5sw5Rta7pzwVcRETNhJ//mnw3Ws0pCu7H5gHuwtnXjDaHxK5y/lll14XatHTCWA0wRBi45iAoJKYKStzB+QS7F2biIEwaBBR0OoeFCOZu1zQy0lTtwhYQ0zth1jr8usPtU=
-#     file_glob: true
-#     file: bin-package/*.tar.gz
-#     skip_cleanup: true
-#     # publish only if we're building a tag and if the SKIP_DEPLOY is set to 0
-#     on:
-#         tags: true
-#         condition: $SKIP_DEPLOY = 0
-#     name: Version $TRAVIS_TAG
+    before_install:
+      - choco install nodist
+      - choco upgrade yarn
+      - export PATH="/c/Program Files (x86)/Yarn/bin:/c/Program Files (x86)/Nodist/bin:$PATH"
+    install:
+      - ls "/c/Program Files"
+      - export NODE_PATH="/c/Program Files (x86)\Nodist\bin\node_modules;$NODE_PATH"
+      - export NODIST_PREFIX="/c/Program Files (x86)\Nodist"
+      - export NODIST_X64=1
+      - nodist add $TRAVIS_NODE_VERSION
+      - nodist $TRAVIS_NODE_VERSION
+      - node -e "console.log(process.argv[0], process.arch, process.versions)"
+      - rustup component add rustfmt-preview
+      # bring in holochain-rust for prebuilt 4.1 zmq binary
+      - git clone https://github.com/holochain/holochain-rust.git
+      - yarn install --ignore-scripts
+      - npm install --scripts-prepend-node-path=true --global --vs2015 --production windows-build-tools
+      # deps for neon, found at https://guides.neon-bindings.com/getting-started/
+      - yarn config set python python2.7
+      - npm config set msvs_version 2015
+      - yarn config set msvs_version 2015 --global
+    script:
+      - PATH=$PATH:/c/Users/travis/build/Connoropolous/holochain-nodejs/holochain-rust/vendor/zmq/bin
+      - cat ./node_modules/.bin/node-pre-gyp
+      - node publish.js

--- a/.travis.yml
+++ b/.travis.yml
@@ -57,7 +57,7 @@ jobs:
     - SKIP_DEPLOY=0
     if: tag =~ /^v\d+\.\d+\.\d+/ OR branch = master OR type = pull_request
     install:
-    - <<: *install_unix_template
+    - *install_unix_template
   - name: "OSX - Node 8"
     os: osx
     env:
@@ -65,7 +65,7 @@ jobs:
     - SKIP_DEPLOY=0
     if: tag =~ /^v\d+\.\d+\.\d+/ OR branch = master OR type = pull_request
     install:
-    - <<: *install_unix_template
+    - *install_unix_template
   - name: "Windows - Node 8"
     os: windows
     rust:
@@ -77,7 +77,7 @@ jobs:
     - LIBZMQ_PREFIX=C:\\Users\\travis\\build\\holochain\\holochain-nodejs\\holochain-rust\\vendor\\zmq
     if: tag =~ /^v\d+\.\d+\.\d+/ OR branch = master OR type = pull_request
     install:
-    - <<: *install_windows_template
+    - *install_windows_template
   - name: "Linux - Node 10"
     os: linux
     env:
@@ -85,7 +85,7 @@ jobs:
     - SKIP_DEPLOY=0
     if: tag =~ /^v\d+\.\d+\.\d+/ OR branch = master OR type = pull_request
     install:
-    - <<: *install_unix_template
+    - *install_unix_template
   - name: "OSX - Node 10"
     os: osx
     env:
@@ -93,7 +93,7 @@ jobs:
     - SKIP_DEPLOY=0
     if: tag =~ /^v\d+\.\d+\.\d+/ OR branch = master OR type = pull_request
     install:
-    - <<: *install_unix_template
+    - *install_unix_template
   - name: "Windows - Node 10"
     os: windows
     rust:
@@ -105,7 +105,7 @@ jobs:
     - LIBZMQ_PREFIX=C:\\Users\\travis\\build\\holochain\\holochain-nodejs\\holochain-rust\\vendor\\zmq
     if: tag =~ /^v\d+\.\d+\.\d+/ OR branch = master OR type = pull_request
     install:
-    - <<: *install_windows_template
+    - *install_windows_template
   - name: "Linux - Node 11"
     os: linux
     env:
@@ -113,7 +113,7 @@ jobs:
     - SKIP_DEPLOY=0
     if: tag =~ /^v\d+\.\d+\.\d+/ OR branch = master OR type = pull_request
     install:
-    - <<: *install_unix_template
+    - *install_unix_template
   - name: "OSX - Node 11"
     os: osx
     env:
@@ -121,7 +121,7 @@ jobs:
     - SKIP_DEPLOY=0
     if: tag =~ /^v\d+\.\d+\.\d+/ OR branch = master OR type = pull_request
     install:
-    - <<: *install_unix_template
+    - *install_unix_template
   - name: "Windows - Node 11"
     os: windows
     rust:
@@ -133,7 +133,7 @@ jobs:
     - LIBZMQ_PREFIX=C:\\Users\\travis\\build\\holochain\\holochain-nodejs\\holochain-rust\\vendor\\zmq
     if: tag =~ /^v\d+\.\d+\.\d+/ OR branch = master OR type = pull_request
     install:
-    - <<: *install_windows_template
+    - *install_windows_template
   
 
   # NOTE

--- a/.travis.yml
+++ b/.travis.yml
@@ -48,6 +48,7 @@ jobs:
     - SKIP_DEPLOY=0
     if: tag =~ /^v\d+\.\d+\.\d+/ OR branch = master OR type = pull_request
 
+  # 
   # # Publish to npm only on release tag
   # - stage: publish
   #   name: "Publish to npm"

--- a/.travis.yml
+++ b/.travis.yml
@@ -63,13 +63,19 @@ jobs:
   #     - echo "Deploying to NPM..."
   #     - node publish.js --publish
 
+
+before_install:
+  - choco install nodist
+
 install:
-  # install our own nodejs to get a reasonable version
-  - rm -rf ~/.nvm && git clone https://github.com/creationix/nvm.git ~/.nvm && (cd ~/.nvm && git checkout `git describe --abbrev=0 --tags`) && source ~/.nvm/nvm.sh && nvm install $TRAVIS_NODE_VERSION
+  - nodist global $TRAVIS_NODE_VERSION
+  - choco install yarn
   
+  # install our own nodejs to get a reasonable version
+  # - rm -rf ~/.nvm && git clone https://github.com/creationix/nvm.git ~/.nvm && (cd ~/.nvm && git checkout `git describe --abbrev=0 --tags`) && source ~/.nvm/nvm.sh && nvm install $TRAVIS_NODE_VERSION
   # install our own yarn to make things work on osx
-  - curl -o- -L https://yarnpkg.com/install.sh | bash -s -- --version 1.10.1
-  - export PATH=$HOME/.yarn/bin:$PATH
+  # - curl -o- -L https://yarnpkg.com/install.sh | bash -s -- --version 1.10.1
+  # - export PATH=$HOME/.yarn/bin:$PATH
 
 cache:
     yarn: true

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,45 +13,55 @@ jobs:
 
   # PRs, pushes to master, and tags build on all target arches
   # if this is release tag, the resultant binary will be uploaded to github
-  - name: "Linux - Node 8"
-    os: linux
+  # - name: "Linux - Node 8"
+  #   os: linux
+  #   env:
+  #   - TRAVIS_NODE_VERSION="8"
+  #   - SKIP_DEPLOY=0
+  #   if: tag =~ /^v\d+\.\d+\.\d+/ OR branch = master OR type = pull_request
+
+  # - name: "OSX - Node 8"
+  #   os: osx
+  #   env:
+  #   - TRAVIS_NODE_VERSION="8"
+  #   - SKIP_DEPLOY=0
+  #   if: tag =~ /^v\d+\.\d+\.\d+/ OR branch = master OR type = pull_request
+
+  # - name: "Linux - Node 10"
+  #   os: linux
+  #   env:
+  #   - TRAVIS_NODE_VERSION="10"
+  #   - SKIP_DEPLOY=0
+  #   if: tag =~ /^v\d+\.\d+\.\d+/ OR branch = master OR type = pull_request
+
+  # - name: "OSX - Node 10"
+  #   os: osx
+  #   env:
+  #   - TRAVIS_NODE_VERSION="10"
+  #   - SKIP_DEPLOY=0
+  #   if: tag =~ /^v\d+\.\d+\.\d+/ OR branch = master OR type = pull_request
+
+  - name: "Windows - Node 8"
+    os: windows
     env:
     - TRAVIS_NODE_VERSION="8"
-    - SKIP_DEPLOY=0
-    if: tag =~ /^v\d+\.\d+\.\d+/ OR branch = master OR type = pull_request
-  - name: "OSX - Node 8"
-    os: osx
-    env:
-    - TRAVIS_NODE_VERSION="8"
-    - SKIP_DEPLOY=0
-    if: tag =~ /^v\d+\.\d+\.\d+/ OR branch = master OR type = pull_request
-  - name: "Linux - Node 10"
-    os: linux
-    env:
-    - TRAVIS_NODE_VERSION="10"
-    - SKIP_DEPLOY=0
-    if: tag =~ /^v\d+\.\d+\.\d+/ OR branch = master OR type = pull_request
-  - name: "OSX - Node 10"
-    os: osx
-    env:
-    - TRAVIS_NODE_VERSION="10"
     - SKIP_DEPLOY=0
     if: tag =~ /^v\d+\.\d+\.\d+/ OR branch = master OR type = pull_request
 
-  # Publish to npm only on release tag
-  - stage: publish
-    name: "Publish to npm"
-    os: linux
-    env: 
-      - TRAVIS_NODE_VERSION="8"
-      - SKIP_DEPLOY=1
+  # # Publish to npm only on release tag
+  # - stage: publish
+  #   name: "Publish to npm"
+  #   os: linux
+  #   env: 
+  #     - TRAVIS_NODE_VERSION="8"
+  #     - SKIP_DEPLOY=1
       
-    if: tag =~ /^v\d+\.\d+\.\d+/
-    before_install:
-      - npm config set //registry.npmjs.org/:_authToken=$NPM_TOKEN
-    script: 
-      - echo "Deploying to NPM..."
-      - node publish.js --publish
+  #   if: tag =~ /^v\d+\.\d+\.\d+/
+  #   before_install:
+  #     - npm config set //registry.npmjs.org/:_authToken=$NPM_TOKEN
+  #   script: 
+  #     - echo "Deploying to NPM..."
+  #     - node publish.js --publish
 
 install:
   # install our own nodejs to get a reasonable version
@@ -73,17 +83,17 @@ script:
     # - pushd native/ && cargo fmt -- --check && popd
     - node publish.js
 
-# deploy the node-pre-gyp binary to github releases so it's there when the npm package is installed
-deploy:
-    provider: releases
-    api_key:
-        secure: XJ7YlkRvxWVRHsn9mv9G2mrdqX3gtLOQqBFuPMEZu4v72QElsDxQRNRBBc+AsAUofSlMaxYvVA8eccF8ddMoFyCAfWqDqGYBdiGxjGANlnP6At/uK3pQe18xnG6G/0HX9wvtxojfp9b3SSunsz8blwsQTTpiKtl3owpd5s/zLT351UrK805QDcFyKrNtAe2W8RWxhqveIzmYpKD0znSvKHZCrChIxj3A+sx1EUGnGVwDDGqpQfmgQuin85Lws146I/JHyr2cYxWo4K+MyCMkPoV4MfEAGfFxTdrjVDDH6NGaoVfFggVVH2i/U1dSojGjVyz6/nWHgJfIR77AcpbG9LMcQYQPuoPWcGo7jfW3VylnD9w09LOawMGG0d7D2vS7KqQbq/4wT5RZGdY4rQQ5An285M/oWxyFqlFoN831EnRJvojygsBGg4rTCTrs32wBOq8mtdH/T6ejp0v5Y1+qp6sx+EsFlLyeki8YKwuSZpu/IRVq7P6QTQt3cWRR35SNu4AyIO4C7izghwTKVqnF+J7uVub5hr2uFrjSH6Os6ArvzciBaYcoznLcYu/91ufTv2D8PbzmEOfjNdaJpfL1UC1ElTLJncmrMZ7IfH/jePTEd5kvR7Vze5fBL5ibnMtjr/KJHFBTH2lR2CYd0W9HQJcFN1rpQJ00UgtOydSbuaE=
-    file_glob: true
-    file: bin-package/*.tar.gz
-    skip_cleanup: true
+# # deploy the node-pre-gyp binary to github releases so it's there when the npm package is installed
+# deploy:
+#     provider: releases
+#     api_key:
+#         secure: XJ7YlkRvxWVRHsn9mv9G2mrdqX3gtLOQqBFuPMEZu4v72QElsDxQRNRBBc+AsAUofSlMaxYvVA8eccF8ddMoFyCAfWqDqGYBdiGxjGANlnP6At/uK3pQe18xnG6G/0HX9wvtxojfp9b3SSunsz8blwsQTTpiKtl3owpd5s/zLT351UrK805QDcFyKrNtAe2W8RWxhqveIzmYpKD0znSvKHZCrChIxj3A+sx1EUGnGVwDDGqpQfmgQuin85Lws146I/JHyr2cYxWo4K+MyCMkPoV4MfEAGfFxTdrjVDDH6NGaoVfFggVVH2i/U1dSojGjVyz6/nWHgJfIR77AcpbG9LMcQYQPuoPWcGo7jfW3VylnD9w09LOawMGG0d7D2vS7KqQbq/4wT5RZGdY4rQQ5An285M/oWxyFqlFoN831EnRJvojygsBGg4rTCTrs32wBOq8mtdH/T6ejp0v5Y1+qp6sx+EsFlLyeki8YKwuSZpu/IRVq7P6QTQt3cWRR35SNu4AyIO4C7izghwTKVqnF+J7uVub5hr2uFrjSH6Os6ArvzciBaYcoznLcYu/91ufTv2D8PbzmEOfjNdaJpfL1UC1ElTLJncmrMZ7IfH/jePTEd5kvR7Vze5fBL5ibnMtjr/KJHFBTH2lR2CYd0W9HQJcFN1rpQJ00UgtOydSbuaE=
+#     file_glob: true
+#     file: bin-package/*.tar.gz
+#     skip_cleanup: true
 
-    # publish only if we're building a tag and if the SKIP_DEPLOY is set to 0
-    on:
-        tags: true
-        condition: $SKIP_DEPLOY = 0
-    name: Version $TRAVIS_TAG
+#     # publish only if we're building a tag and if the SKIP_DEPLOY is set to 0
+#     on:
+#         tags: true
+#         condition: $SKIP_DEPLOY = 0
+#     name: Version $TRAVIS_TAG

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,14 +14,13 @@ jobs:
     - RUST_BACKTRACE=1
     - TRAVIS_NODE_VERSION="10"
     - SKIP_DEPLOY=0
-    - LIBZMQ_PREFIX=C:\\Users\\travis\\build\\Connoropolous\\holochain-nodejs\\holochain-rust\\vendor\\zmq
+    - LIBZMQ_PREFIX=C:\\Users\\travis\\build\\holochain\\holochain-nodejs\\holochain-rust\\vendor\\zmq
     if: tag =~ /^v\d+\.\d+\.\d+/ OR branch = master OR type = pull_request
     before_install:
       - choco install nodist
       - choco upgrade yarn
       - export PATH="/c/Program Files (x86)/Yarn/bin:/c/Program Files (x86)/Nodist/bin:$PATH"
     install:
-      - ls "/c/Program Files"
       - export NODE_PATH="/c/Program Files (x86)\Nodist\bin\node_modules;$NODE_PATH"
       - export NODIST_PREFIX="/c/Program Files (x86)\Nodist"
       - export NODIST_X64=1
@@ -38,6 +37,5 @@ jobs:
       - npm config set msvs_version 2015
       - yarn config set msvs_version 2015 --global
     script:
-      - PATH=$PATH:/c/Users/travis/build/Connoropolous/holochain-nodejs/holochain-rust/vendor/zmq/bin
-      - cat ./node_modules/.bin/node-pre-gyp
+      - PATH=$PATH:/c/Users/travis/build/holochain/holochain-nodejs/holochain-rust/vendor/zmq/bin
       - node publish.js

--- a/.travis.yml
+++ b/.travis.yml
@@ -66,8 +66,9 @@ jobs:
 
 install:
   - choco install nodist
-  - nodist global $TRAVIS_NODE_VERSION
   - choco install yarn
+  - nodist add $TRAVIS_NODE_VERSION
+  - nodist $TRAVIS_NODE_VERSION
   # configuration borrowed from holochain-rust Makefile, showing how to install zmq for ubuntu trusty on travis
   # - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then
   #     echo "deb http://download.opensuse.org/repositories/network:/messaging:/zeromq:/release-stable/xUbuntu_14.04/ ./" >> /etc/apt/sources.list;

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,6 +9,7 @@ stages:
   - publish
 
 _install_unix_template: &_install_unix_template
+  install:
   # configuration borrowed from holochain-rust Makefile, showing how to install zmq for ubuntu trusty on travis
   - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then
       echo "deb http://download.opensuse.org/repositories/network:/messaging:/zeromq:/release-stable/xUbuntu_14.04/ ./" >> /etc/apt/sources.list;
@@ -26,6 +27,7 @@ _install_unix_template: &_install_unix_template
   - export PATH=$HOME/.yarn/bin:$PATH
 
 _install_windows_template: &_install_windows_template
+  install:
   - choco install nodist
   - choco upgrade yarn
   - export PATH="/c/Program Files (x86)/Yarn/bin:/c/Program Files (x86)/Nodist/bin:$PATH"
@@ -56,7 +58,6 @@ jobs:
     - TRAVIS_NODE_VERSION="8"
     - SKIP_DEPLOY=0
     if: tag =~ /^v\d+\.\d+\.\d+/ OR branch = add-windows-build OR type = pull_request
-    install:
     - *install_unix_template
   - name: "OSX - Node 8"
     os: osx
@@ -64,7 +65,6 @@ jobs:
     - TRAVIS_NODE_VERSION="8"
     - SKIP_DEPLOY=0
     if: tag =~ /^v\d+\.\d+\.\d+/ OR branch = add-windows-build OR type = pull_request
-    install:
     - *install_unix_template
   - name: "Windows - Node 8"
     os: windows
@@ -76,7 +76,6 @@ jobs:
     - SKIP_DEPLOY=0
     - LIBZMQ_PREFIX=C:\\Users\\travis\\build\\holochain\\holochain-nodejs\\holochain-rust\\vendor\\zmq
     if: tag =~ /^v\d+\.\d+\.\d+/ OR branch = add-windows-build OR type = pull_request
-    install:
     - *install_windows_template
   - name: "Linux - Node 10"
     os: linux
@@ -84,7 +83,6 @@ jobs:
     - TRAVIS_NODE_VERSION="10"
     - SKIP_DEPLOY=0
     if: tag =~ /^v\d+\.\d+\.\d+/ OR branch = add-windows-build OR type = pull_request
-    install:
     - *install_unix_template
   - name: "OSX - Node 10"
     os: osx
@@ -92,7 +90,6 @@ jobs:
     - TRAVIS_NODE_VERSION="10"
     - SKIP_DEPLOY=0
     if: tag =~ /^v\d+\.\d+\.\d+/ OR branch = add-windows-build OR type = pull_request
-    install:
     - *install_unix_template
   - name: "Windows - Node 10"
     os: windows
@@ -104,7 +101,6 @@ jobs:
     - SKIP_DEPLOY=0
     - LIBZMQ_PREFIX=C:\\Users\\travis\\build\\holochain\\holochain-nodejs\\holochain-rust\\vendor\\zmq
     if: tag =~ /^v\d+\.\d+\.\d+/ OR branch = add-windows-build OR type = pull_request
-    install:
     - *install_windows_template
   - name: "Linux - Node 11"
     os: linux
@@ -112,7 +108,6 @@ jobs:
     - TRAVIS_NODE_VERSION="11"
     - SKIP_DEPLOY=0
     if: tag =~ /^v\d+\.\d+\.\d+/ OR branch = add-windows-build OR type = pull_request
-    install:
     - *install_unix_template
   - name: "OSX - Node 11"
     os: osx
@@ -120,7 +115,6 @@ jobs:
     - TRAVIS_NODE_VERSION="11"
     - SKIP_DEPLOY=0
     if: tag =~ /^v\d+\.\d+\.\d+/ OR branch = add-windows-build OR type = pull_request
-    install:
     - *install_unix_template
   - name: "Windows - Node 11"
     os: windows
@@ -132,7 +126,6 @@ jobs:
     - SKIP_DEPLOY=0
     - LIBZMQ_PREFIX=C:\\Users\\travis\\build\\holochain\\holochain-nodejs\\holochain-rust\\vendor\\zmq
     if: tag =~ /^v\d+\.\d+\.\d+/ OR branch = add-windows-build OR type = pull_request
-    install:
     - *install_windows_template
 
   # NOTE

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,15 @@
-sudo: true
+sudo: false
 language: rust
+rust:
+  - nightly-2018-10-12-x86_64-pc-windows-msvc
+
+stages:
+  - test
+  - publish
 
 jobs:
   include:
   - name: "Windows - Node 8"
-    rust: nightly-2018-10-12-x86_64-pc-windows-msvc
     os: windows
     env:
     - RUST_BACKTRACE=1
@@ -12,10 +17,12 @@ jobs:
     - SKIP_DEPLOY=0
     - LIBZMQ_PREFIX=C:\\Users\\travis\\build\\holochain\\holochain-nodejs\\holochain-rust\\vendor\\zmq
     if: tag =~ /^v\d+\.\d+\.\d+/ OR branch = master OR type = pull_request
+
 before_install:
   - choco install nodist
   - choco upgrade yarn
   - export PATH="/c/Program Files (x86)/Yarn/bin:/c/Program Files (x86)/Nodist/bin:$PATH"
+
 install:
   - export NODE_PATH="/c/Program Files (x86)\Nodist\bin\node_modules;$NODE_PATH"
   - export NODIST_PREFIX="/c/Program Files (x86)\Nodist"
@@ -32,6 +39,7 @@ install:
   - yarn config set python python2.7
   - npm config set msvs_version 2015
   - yarn config set msvs_version 2015 --global
+
 script:
   - PATH=$PATH:/c/Users/travis/build/holochain/holochain-nodejs/holochain-rust/vendor/zmq/bin
   - node publish.js

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,8 @@ language: rust
 # all unlabeled jobs run at test. Only if all "test" jobs finish, will the publish job run
 stages:
   - test
-  - publish
+  # See notes below about why publish is not enabled
+  # - publish
 
 _install_unix_template: &_install_unix_template
   rust: nightly
@@ -134,7 +135,7 @@ jobs:
   #     - echo "Deploying to NPM..."
   #     - node publish.js --publish
 
-# all of this can be common between windows and unix
+# all of this is common between windows and unix
 cache:
     yarn: true
     cargo: true

--- a/.travis.yml
+++ b/.travis.yml
@@ -64,11 +64,12 @@ jobs:
   #     - echo "Deploying to NPM..."
   #     - node publish.js --publish
 
-before_install:
+install:
   - choco install nodist
   - choco install yarn
-
-install:
+  - Install-ChocolateyPath -PathToInstall "C:\ProgramData\Chocolatey\nodist"
+  - Install-ChocolateyPath -PathToInstall "C:\ProgramData\Chocolatey\yarn"
+  - refreshenv
   - nodist add $TRAVIS_NODE_VERSION
   - nodist $TRAVIS_NODE_VERSION
   # configuration borrowed from holochain-rust Makefile, showing how to install zmq for ubuntu trusty on travis

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,5 @@
 sudo: true
 language: rust
-rust:
-- nightly
 
 # all unlabeled jobs run at test. Only if all "test" jobs finish, will the publish job run
 stages:
@@ -9,6 +7,7 @@ stages:
   - publish
 
 _install_unix_template: &_install_unix_template
+  rust: nightly
   install:
   # configuration borrowed from holochain-rust Makefile, showing how to install zmq for ubuntu trusty on travis
   - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then
@@ -25,6 +24,8 @@ _install_unix_template: &_install_unix_template
   - export PATH=$HOME/.yarn/bin:$PATH
 
 _install_windows_template: &_install_windows_template
+  os: windows
+  rust: nightly-2018-10-12-x86_64-pc-windows-msvc
   install:
   - choco install nodist
   - choco upgrade yarn
@@ -64,10 +65,6 @@ jobs:
     if: tag =~ /^v\d+\.\d+\.\d+/ OR branch = add-windows-build OR type = pull_request
   - <<: *_install_windows_template
     name: "Windows - Node 8"
-    os: windows
-    rust:
-    # match the rust windows nightly version from holochain-rust
-    - nightly-2018-10-12-x86_64-pc-windows-msvc
     env:
     - TRAVIS_NODE_VERSION="8"
     - SKIP_DEPLOY=0
@@ -89,10 +86,6 @@ jobs:
     if: tag =~ /^v\d+\.\d+\.\d+/ OR branch = add-windows-build OR type = pull_request
   - <<: *_install_windows_template
     name: "Windows - Node 10"
-    os: windows
-    rust:
-    # match the rust windows nightly version from holochain-rust
-    - nightly-2018-10-12-x86_64-pc-windows-msvc
     env:
     - TRAVIS_NODE_VERSION="10"
     - SKIP_DEPLOY=0
@@ -114,10 +107,6 @@ jobs:
     if: tag =~ /^v\d+\.\d+\.\d+/ OR branch = add-windows-build OR type = pull_request
   - <<: *_install_windows_template
     name: "Windows - Node 11"
-    os: windows
-    rust:
-    # match the rust windows nightly version from holochain-rust
-    - nightly-2018-10-12-x86_64-pc-windows-msvc
     env:
     - TRAVIS_NODE_VERSION="11"
     - SKIP_DEPLOY=0

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,9 @@
+sudo: true
+language: rust
+
 jobs:
   include:
   - name: "Windows - Node 8"
-    sudo: true
-    language: rust
     rust: nightly-2018-10-12-x86_64-pc-windows-msvc
     os: windows
     env:
@@ -11,26 +12,26 @@ jobs:
     - SKIP_DEPLOY=0
     - LIBZMQ_PREFIX=C:\\Users\\travis\\build\\holochain\\holochain-nodejs\\holochain-rust\\vendor\\zmq
     if: tag =~ /^v\d+\.\d+\.\d+/ OR branch = master OR type = pull_request
-    before_install:
-      - choco install nodist
-      - choco upgrade yarn
-      - export PATH="/c/Program Files (x86)/Yarn/bin:/c/Program Files (x86)/Nodist/bin:$PATH"
-    install:
-      - export NODE_PATH="/c/Program Files (x86)\Nodist\bin\node_modules;$NODE_PATH"
-      - export NODIST_PREFIX="/c/Program Files (x86)\Nodist"
-      - export NODIST_X64=1
-      - nodist add $TRAVIS_NODE_VERSION
-      - nodist $TRAVIS_NODE_VERSION
-      - node -e "console.log(process.argv[0], process.arch, process.versions)"
-      - rustup component add rustfmt-preview
-      # bring in holochain-rust for prebuilt 4.1 zmq binary
-      - git clone https://github.com/holochain/holochain-rust.git
-      - yarn install --ignore-scripts
-      - npm install --scripts-prepend-node-path=true --global --vs2015 --production windows-build-tools
-      # deps for neon, found at https://guides.neon-bindings.com/getting-started/
-      - yarn config set python python2.7
-      - npm config set msvs_version 2015
-      - yarn config set msvs_version 2015 --global
-    script:
-      - PATH=$PATH:/c/Users/travis/build/holochain/holochain-nodejs/holochain-rust/vendor/zmq/bin
-      - node publish.js
+before_install:
+  - choco install nodist
+  - choco upgrade yarn
+  - export PATH="/c/Program Files (x86)/Yarn/bin:/c/Program Files (x86)/Nodist/bin:$PATH"
+install:
+  - export NODE_PATH="/c/Program Files (x86)\Nodist\bin\node_modules;$NODE_PATH"
+  - export NODIST_PREFIX="/c/Program Files (x86)\Nodist"
+  - export NODIST_X64=1
+  - nodist add $TRAVIS_NODE_VERSION
+  - nodist $TRAVIS_NODE_VERSION
+  - node -e "console.log(process.argv[0], process.arch, process.versions)"
+  - rustup component add rustfmt-preview
+  # bring in holochain-rust for prebuilt 4.1 zmq binary
+  - git clone https://github.com/holochain/holochain-rust.git
+  - yarn install --ignore-scripts
+  - npm install --scripts-prepend-node-path=true --global --vs2015 --production windows-build-tools
+  # deps for neon, found at https://guides.neon-bindings.com/getting-started/
+  - yarn config set python python2.7
+  - npm config set msvs_version 2015
+  - yarn config set msvs_version 2015 --global
+script:
+  - PATH=$PATH:/c/Users/travis/build/holochain/holochain-nodejs/holochain-rust/vendor/zmq/bin
+  - node publish.js

--- a/.travis.yml
+++ b/.travis.yml
@@ -49,24 +49,24 @@ _install_windows_template: &_install_windows_template
 
 jobs:
   include:
-
   # PRs, pushes to master, and tags build on all target arches
   # if this is release tag, the resultant binary will be uploaded to github
-  - name: "Linux - Node 8"
+  - <<: *install_unix_template
+    name: "Linux - Node 8"
     os: linux
     env:
     - TRAVIS_NODE_VERSION="8"
     - SKIP_DEPLOY=0
     if: tag =~ /^v\d+\.\d+\.\d+/ OR branch = add-windows-build OR type = pull_request
-    - *install_unix_template
-  - name: "OSX - Node 8"
+  - <<: *install_unix_template
+    name: "OSX - Node 8"
     os: osx
     env:
     - TRAVIS_NODE_VERSION="8"
     - SKIP_DEPLOY=0
     if: tag =~ /^v\d+\.\d+\.\d+/ OR branch = add-windows-build OR type = pull_request
-    - *install_unix_template
-  - name: "Windows - Node 8"
+  - <<: *install_windows_template
+    name: "Windows - Node 8"
     os: windows
     rust:
     # match the rust windows nightly version from holochain-rust
@@ -76,22 +76,22 @@ jobs:
     - SKIP_DEPLOY=0
     - LIBZMQ_PREFIX=C:\\Users\\travis\\build\\holochain\\holochain-nodejs\\holochain-rust\\vendor\\zmq
     if: tag =~ /^v\d+\.\d+\.\d+/ OR branch = add-windows-build OR type = pull_request
-    - *install_windows_template
-  - name: "Linux - Node 10"
+  - <<: *install_unix_template
+    name: "Linux - Node 10"
     os: linux
     env:
     - TRAVIS_NODE_VERSION="10"
     - SKIP_DEPLOY=0
     if: tag =~ /^v\d+\.\d+\.\d+/ OR branch = add-windows-build OR type = pull_request
-    - *install_unix_template
-  - name: "OSX - Node 10"
+  - <<: *install_unix_template
+    name: "OSX - Node 10"
     os: osx
     env:
     - TRAVIS_NODE_VERSION="10"
     - SKIP_DEPLOY=0
     if: tag =~ /^v\d+\.\d+\.\d+/ OR branch = add-windows-build OR type = pull_request
-    - *install_unix_template
-  - name: "Windows - Node 10"
+  - <<: *install_windows_template
+    name: "Windows - Node 10"
     os: windows
     rust:
     # match the rust windows nightly version from holochain-rust
@@ -101,22 +101,22 @@ jobs:
     - SKIP_DEPLOY=0
     - LIBZMQ_PREFIX=C:\\Users\\travis\\build\\holochain\\holochain-nodejs\\holochain-rust\\vendor\\zmq
     if: tag =~ /^v\d+\.\d+\.\d+/ OR branch = add-windows-build OR type = pull_request
-    - *install_windows_template
-  - name: "Linux - Node 11"
+  - <<: *install_unix_template
+    name: "Linux - Node 11"
     os: linux
     env:
     - TRAVIS_NODE_VERSION="11"
     - SKIP_DEPLOY=0
     if: tag =~ /^v\d+\.\d+\.\d+/ OR branch = add-windows-build OR type = pull_request
-    - *install_unix_template
-  - name: "OSX - Node 11"
+  - <<: *install_unix_template
+    name: "OSX - Node 11"
     os: osx
     env:
     - TRAVIS_NODE_VERSION="11"
     - SKIP_DEPLOY=0
     if: tag =~ /^v\d+\.\d+\.\d+/ OR branch = add-windows-build OR type = pull_request
-    - *install_unix_template
-  - name: "Windows - Node 11"
+  - <<: *install_windows_template
+    name: "Windows - Node 11"
     os: windows
     rust:
     # match the rust windows nightly version from holochain-rust
@@ -126,7 +126,6 @@ jobs:
     - SKIP_DEPLOY=0
     - LIBZMQ_PREFIX=C:\\Users\\travis\\build\\holochain\\holochain-nodejs\\holochain-rust\\vendor\\zmq
     if: tag =~ /^v\d+\.\d+\.\d+/ OR branch = add-windows-build OR type = pull_request
-    - *install_windows_template
 
   # NOTE
   # the following is all commented out because windows travis

--- a/native/Cargo.lock
+++ b/native/Cargo.lock
@@ -42,6 +42,14 @@ dependencies = [
 ]
 
 [[package]]
+name = "base64"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "byteorder 1.2.7 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "bitflags"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -163,9 +171,9 @@ name = "failure_derive"
 version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "proc-macro2 0.4.23 (registry+https://github.com/rust-lang/crates.io-index)",
+ "proc-macro2 0.4.24 (registry+https://github.com/rust-lang/crates.io-index)",
  "quote 0.6.10 (registry+https://github.com/rust-lang/crates.io-index)",
- "syn 0.15.20 (registry+https://github.com/rust-lang/crates.io-index)",
+ "syn 0.15.21 (registry+https://github.com/rust-lang/crates.io-index)",
  "synstructure 0.10.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -326,7 +334,7 @@ dependencies = [
 [[package]]
 name = "holochain_cas_implementations"
 version = "0.0.1"
-source = "git+https://github.com/holochain/holochain-rust?branch=develop#a853b4a6fd4ada1e1e0c0a31bf95e98d8ea06ae7"
+source = "git+https://github.com/holochain/holochain-rust?branch=develop#d9c0431a5b49a33f147f13187750b089eb321392"
 dependencies = [
  "futures-preview 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "holochain_core_types 0.0.1 (git+https://github.com/holochain/holochain-rust?branch=develop)",
@@ -348,7 +356,7 @@ dependencies = [
 [[package]]
 name = "holochain_container_api"
 version = "0.0.1"
-source = "git+https://github.com/holochain/holochain-rust?branch=develop#a853b4a6fd4ada1e1e0c0a31bf95e98d8ea06ae7"
+source = "git+https://github.com/holochain/holochain-rust?branch=develop#d9c0431a5b49a33f147f13187750b089eb321392"
 dependencies = [
  "boolinator 2.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures-preview 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -365,7 +373,7 @@ dependencies = [
 [[package]]
 name = "holochain_core"
 version = "0.0.1"
-source = "git+https://github.com/holochain/holochain-rust?branch=develop#a853b4a6fd4ada1e1e0c0a31bf95e98d8ea06ae7"
+source = "git+https://github.com/holochain/holochain-rust?branch=develop#d9c0431a5b49a33f147f13187750b089eb321392"
 dependencies = [
  "bitflags 1.0.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "chrono 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -395,13 +403,16 @@ dependencies = [
 [[package]]
 name = "holochain_core_types"
 version = "0.0.1"
-source = "git+https://github.com/holochain/holochain-rust?branch=develop#a853b4a6fd4ada1e1e0c0a31bf95e98d8ea06ae7"
+source = "git+https://github.com/holochain/holochain-rust?branch=develop#d9c0431a5b49a33f147f13187750b089eb321392"
 dependencies = [
+ "arrayref 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "base64 0.10.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "bitflags 1.0.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures-preview 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "holochain_core_types_derive 0.0.1 (git+https://github.com/holochain/holochain-rust?branch=develop)",
  "multihash 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "objekt 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "reed-solomon 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "rust-base58 0.0.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.80 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_derive 1.0.80 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -413,7 +424,7 @@ dependencies = [
 [[package]]
 name = "holochain_core_types_derive"
 version = "0.0.1"
-source = "git+https://github.com/holochain/holochain-rust?branch=develop#a853b4a6fd4ada1e1e0c0a31bf95e98d8ea06ae7"
+source = "git+https://github.com/holochain/holochain-rust?branch=develop#d9c0431a5b49a33f147f13187750b089eb321392"
 dependencies = [
  "quote 0.6.10 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.80 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -424,7 +435,7 @@ dependencies = [
 [[package]]
 name = "holochain_dna"
 version = "0.0.1"
-source = "git+https://github.com/holochain/holochain-rust?branch=develop#a853b4a6fd4ada1e1e0c0a31bf95e98d8ea06ae7"
+source = "git+https://github.com/holochain/holochain-rust?branch=develop#d9c0431a5b49a33f147f13187750b089eb321392"
 dependencies = [
  "base64 0.9.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "holochain_core_types 0.0.1 (git+https://github.com/holochain/holochain-rust?branch=develop)",
@@ -438,20 +449,21 @@ dependencies = [
 [[package]]
 name = "holochain_net"
 version = "0.0.1"
-source = "git+https://github.com/holochain/holochain-rust?branch=develop#a853b4a6fd4ada1e1e0c0a31bf95e98d8ea06ae7"
+source = "git+https://github.com/holochain/holochain-rust?branch=develop#d9c0431a5b49a33f147f13187750b089eb321392"
 dependencies = [
  "base64 0.9.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "failure 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "holochain_core_types 0.0.1 (git+https://github.com/holochain/holochain-rust?branch=develop)",
  "holochain_net_connection 0.1.0 (git+https://github.com/holochain/holochain-rust?branch=develop)",
  "holochain_net_ipc 0.1.0 (git+https://github.com/holochain/holochain-rust?branch=develop)",
+ "lazy_static 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.33 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "holochain_net_connection"
 version = "0.1.0"
-source = "git+https://github.com/holochain/holochain-rust?branch=develop#a853b4a6fd4ada1e1e0c0a31bf95e98d8ea06ae7"
+source = "git+https://github.com/holochain/holochain-rust?branch=develop#d9c0431a5b49a33f147f13187750b089eb321392"
 dependencies = [
  "byteorder 1.2.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "failure 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -468,7 +480,7 @@ dependencies = [
 [[package]]
 name = "holochain_net_ipc"
 version = "0.1.0"
-source = "git+https://github.com/holochain/holochain-rust?branch=develop#a853b4a6fd4ada1e1e0c0a31bf95e98d8ea06ae7"
+source = "git+https://github.com/holochain/holochain-rust?branch=develop#d9c0431a5b49a33f147f13187750b089eb321392"
 dependencies = [
  "failure 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "holochain_net_connection 0.1.0 (git+https://github.com/holochain/holochain-rust?branch=develop)",
@@ -483,7 +495,7 @@ dependencies = [
 [[package]]
 name = "holochain_wasm_utils"
 version = "0.0.1"
-source = "git+https://github.com/holochain/holochain-rust?branch=develop#a853b4a6fd4ada1e1e0c0a31bf95e98d8ea06ae7"
+source = "git+https://github.com/holochain/holochain-rust?branch=develop#d9c0431a5b49a33f147f13187750b089eb321392"
 dependencies = [
  "holochain_core_types 0.0.1 (git+https://github.com/holochain/holochain-rust?branch=develop)",
  "holochain_core_types_derive 0.0.1 (git+https://github.com/holochain/holochain-rust?branch=develop)",
@@ -673,9 +685,9 @@ version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "num-traits 0.2.6 (registry+https://github.com/rust-lang/crates.io-index)",
- "proc-macro2 0.4.23 (registry+https://github.com/rust-lang/crates.io-index)",
+ "proc-macro2 0.4.24 (registry+https://github.com/rust-lang/crates.io-index)",
  "quote 0.6.10 (registry+https://github.com/rust-lang/crates.io-index)",
- "syn 0.15.20 (registry+https://github.com/rust-lang/crates.io-index)",
+ "syn 0.15.21 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -746,7 +758,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "proc-macro2"
-version = "0.4.23"
+version = "0.4.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "unicode-xid 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -757,7 +769,7 @@ name = "quote"
 version = "0.6.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "proc-macro2 0.4.23 (registry+https://github.com/rust-lang/crates.io-index)",
+ "proc-macro2 0.4.24 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -801,6 +813,11 @@ version = "0.1.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
+name = "reed-solomon"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
 name = "regex"
 version = "0.2.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -829,7 +846,7 @@ name = "regex-syntax"
 version = "0.5.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "ucd-util 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "ucd-util 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -837,7 +854,7 @@ name = "regex-syntax"
 version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "ucd-util 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "ucd-util 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -1038,9 +1055,9 @@ name = "serde_derive"
 version = "1.0.80"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "proc-macro2 0.4.23 (registry+https://github.com/rust-lang/crates.io-index)",
+ "proc-macro2 0.4.24 (registry+https://github.com/rust-lang/crates.io-index)",
  "quote 0.6.10 (registry+https://github.com/rust-lang/crates.io-index)",
- "syn 0.15.20 (registry+https://github.com/rust-lang/crates.io-index)",
+ "syn 0.15.21 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -1096,17 +1113,17 @@ name = "syn"
 version = "0.14.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "proc-macro2 0.4.23 (registry+https://github.com/rust-lang/crates.io-index)",
+ "proc-macro2 0.4.24 (registry+https://github.com/rust-lang/crates.io-index)",
  "quote 0.6.10 (registry+https://github.com/rust-lang/crates.io-index)",
  "unicode-xid 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "syn"
-version = "0.15.20"
+version = "0.15.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "proc-macro2 0.4.23 (registry+https://github.com/rust-lang/crates.io-index)",
+ "proc-macro2 0.4.24 (registry+https://github.com/rust-lang/crates.io-index)",
  "quote 0.6.10 (registry+https://github.com/rust-lang/crates.io-index)",
  "unicode-xid 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -1116,9 +1133,9 @@ name = "synstructure"
 version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "proc-macro2 0.4.23 (registry+https://github.com/rust-lang/crates.io-index)",
+ "proc-macro2 0.4.24 (registry+https://github.com/rust-lang/crates.io-index)",
  "quote 0.6.10 (registry+https://github.com/rust-lang/crates.io-index)",
- "syn 0.15.20 (registry+https://github.com/rust-lang/crates.io-index)",
+ "syn 0.15.21 (registry+https://github.com/rust-lang/crates.io-index)",
  "unicode-xid 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -1181,7 +1198,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "ucd-util"
-version = "0.1.2"
+version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -1306,6 +1323,7 @@ dependencies = [
 "checksum arrayref 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)" = "0d382e583f07208808f6b1249e60848879ba3543f57c32277bf52d69c2f0f0ee"
 "checksum backtrace 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)" = "89a47830402e9981c5c41223151efcced65a0510c13097c769cede7efb34782a"
 "checksum backtrace-sys 0.1.24 (registry+https://github.com/rust-lang/crates.io-index)" = "c66d56ac8dabd07f6aacdaf633f4b8262f5b3601a810a0dcddffd5c22c69daa0"
+"checksum base64 0.10.0 (registry+https://github.com/rust-lang/crates.io-index)" = "621fc7ecb8008f86d7fb9b95356cd692ce9514b80a86d85b397f32a22da7b9e2"
 "checksum base64 0.9.3 (registry+https://github.com/rust-lang/crates.io-index)" = "489d6c0ed21b11d038c31b6ceccca973e65d73ba3bd8ecb9a2babf5546164643"
 "checksum bitflags 1.0.4 (registry+https://github.com/rust-lang/crates.io-index)" = "228047a76f468627ca71776ecdebd732a3423081fcf5125585bcd7c49886ce12"
 "checksum block-buffer 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)" = "a076c298b9ecdb530ed9d967e74a6027d6a7478924520acddcddc24c1c8ab3ab"
@@ -1384,13 +1402,14 @@ dependencies = [
 "checksum objekt 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "7d32585b38ed56d6f37af8d99bca1025bced540f9b8926b1ed4953e00a2d39f4"
 "checksum parity-wasm 0.31.3 (registry+https://github.com/rust-lang/crates.io-index)" = "511379a8194230c2395d2f5fa627a5a7e108a9f976656ce723ae68fca4097bfc"
 "checksum pkg-config 0.3.14 (registry+https://github.com/rust-lang/crates.io-index)" = "676e8eb2b1b4c9043511a9b7bea0915320d7e502b0a079fb03f9635a5252b18c"
-"checksum proc-macro2 0.4.23 (registry+https://github.com/rust-lang/crates.io-index)" = "88dae56b29da695d783ea7fc5a90de281f79eb38407e77f6d674dd8befc4ac47"
+"checksum proc-macro2 0.4.24 (registry+https://github.com/rust-lang/crates.io-index)" = "77619697826f31a02ae974457af0b29b723e5619e113e9397b8b82c6bd253f09"
 "checksum quote 0.6.10 (registry+https://github.com/rust-lang/crates.io-index)" = "53fa22a1994bd0f9372d7a816207d8a2677ad0325b073f5c5332760f0fb62b5c"
 "checksum rand 0.4.3 (registry+https://github.com/rust-lang/crates.io-index)" = "8356f47b32624fef5b3301c1be97e5944ecdd595409cc5da11d05f211db6cfbd"
 "checksum rand 0.5.5 (registry+https://github.com/rust-lang/crates.io-index)" = "e464cd887e869cddcae8792a4ee31d23c7edd516700695608f5b98c67ee0131c"
 "checksum rand_core 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "1961a422c4d189dfb50ffa9320bf1f2a9bd54ecb92792fb9477f99a1045f3372"
 "checksum rand_core 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "0905b6b7079ec73b314d4c748701f6931eb79fd97c668caa3f1899b22b32c6db"
 "checksum redox_syscall 0.1.40 (registry+https://github.com/rust-lang/crates.io-index)" = "c214e91d3ecf43e9a4e41e578973adeb14b474f2bee858742d127af75a0112b1"
+"checksum reed-solomon 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "13de68c877a77f35885442ac72c8beb7c2f0b09380c43b734b9d63d1db69ee54"
 "checksum regex 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)" = "9329abc99e39129fcceabd24cf5d85b4671ef7c29c50e972bc5afe32438ec384"
 "checksum regex 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)" = "ee84f70c8c08744ea9641a731c7fadb475bf2ecc52d7f627feb833e0b3990467"
 "checksum regex-syntax 0.5.6 (registry+https://github.com/rust-lang/crates.io-index)" = "7d707a4fa2637f2dca2ef9fd02225ec7661fe01a53623c1e6515b6916511f7a7"
@@ -1426,7 +1445,7 @@ dependencies = [
 "checksum sha2 0.7.1 (registry+https://github.com/rust-lang/crates.io-index)" = "9eb6be24e4c23a84d7184280d2722f7f2731fcdd4a9d886efbfe4413e4847ea0"
 "checksum snowflake 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "27207bb65232eda1f588cf46db2fee75c0808d557f6b3cf19a75f5d6d7c94df1"
 "checksum syn 0.14.9 (registry+https://github.com/rust-lang/crates.io-index)" = "261ae9ecaa397c42b960649561949d69311f08eeaea86a65696e6e46517cf741"
-"checksum syn 0.15.20 (registry+https://github.com/rust-lang/crates.io-index)" = "8886c8d2774e853fcd7d9d2131f6e40ba46c9c0e358e4d57178452abd6859bb0"
+"checksum syn 0.15.21 (registry+https://github.com/rust-lang/crates.io-index)" = "816b7af21405b011a23554ea2dc3f6576dc86ca557047c34098c1d741f10f823"
 "checksum synstructure 0.10.1 (registry+https://github.com/rust-lang/crates.io-index)" = "73687139bf99285483c96ac0add482c3776528beac1d97d444f6e91f203a2015"
 "checksum tempfile 3.0.4 (registry+https://github.com/rust-lang/crates.io-index)" = "55c1195ef8513f3273d55ff59fe5da6940287a0d7a98331254397f464833675b"
 "checksum thread_local 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)" = "c6b53e329000edc2b34dbe8545fd20e55a333362d0a321909685a19bd28c3f1b"
@@ -1435,7 +1454,7 @@ dependencies = [
 "checksum toml 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "736b60249cb25337bc196faa43ee12c705e426f3d55c214d73a4e7be06f92cb4"
 "checksum toml 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)" = "4a2ecc31b0351ea18b3fe11274b8db6e4d82bce861bbb22e6dbed40417902c65"
 "checksum typenum 1.10.0 (registry+https://github.com/rust-lang/crates.io-index)" = "612d636f949607bdf9b123b4a6f6d966dedf3ff669f7f045890d3a4a73948169"
-"checksum ucd-util 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "d0f8bfa9ff0cadcd210129ad9d2c5f145c13e9ced3d3e5d948a6213487d52444"
+"checksum ucd-util 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)" = "535c204ee4d8434478593480b8f86ab45ec9aae0e83c568ca81abf0fd0e88f86"
 "checksum unicode-xid 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "fc72304796d0818e357ead4e000d19c9c174ab23dc11093ac919054d20a6a7fc"
 "checksum unwrap_to 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "cad414b2eed757c1b6f810f8abc814e298a9c89176b21fae092c7a87756fb839"
 "checksum utf8-ranges 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)" = "796f7e48bef87609f7ade7e06495a87d5cd06c7866e6a5cbfceffc558a243737"

--- a/native/src/app.rs
+++ b/native/src/app.rs
@@ -32,7 +32,7 @@ declare_types! {
             let agent_name = ctx.argument::<JsString>(0)?.to_string(&mut ctx)?.value();
             let dna_data = ctx.argument::<JsString>(1)?.to_string(&mut ctx)?.value();
 
-            let agent = Agent::from(agent_name);
+            let agent = Agent::generate_fake(&agent_name);
 
             let context = Arc::new(HolochainContext::new(
                 agent,

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@holochain/holochain-nodejs",
-  "version": "0.1.12",
+  "version": "0.1.13",
   "description": "Node bindings for holochain",
   "main": "index.js",
   "author": "Julian Laubstein <contact@julianlaubstein.de>",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@holochain/holochain-nodejs",
-  "version": "0.1.13",
+  "version": "0.1.14",
   "description": "Node bindings for holochain",
   "main": "index.js",
   "author": "Julian Laubstein <contact@julianlaubstein.de>",

--- a/package.json
+++ b/package.json
@@ -10,13 +10,14 @@
   },
   "os": [
     "darwin",
-    "linux"
+    "linux",
+    "win32"
   ],
   "cpu": [
     "x64"
   ],
   "scripts": {
-    "compile": "neon build -r",
+    "compile": "neon build --release",
     "clean": "neon clean"
   },
   "dependencies": {

--- a/publish.js
+++ b/publish.js
@@ -43,7 +43,7 @@ shell.rm("-rf", "./dist/native/target");
 
 
 shell.pushd("./native");
-shell.exec("cargo update");
+// shell.exec("cargo update");
 shell.popd();
 shell.exec("yarn run compile");
 

--- a/publish.js
+++ b/publish.js
@@ -52,7 +52,11 @@ fs.writeFileSync("./dist/package.json", JSON.stringify(npmPackageJson, null, 2))
 
 shell.mkdir("./bin-package");
 shell.cp("./native/index.node", "./bin-package");
-shell.exec("./node_modules/.bin/node-pre-gyp package");
+if (process.platform === "win32") {
+    shell.exec("sh node_modules/.bin/node-pre-gyp package");
+} else {
+    shell.exec("./node_modules/.bin/node-pre-gyp package");
+}
 var tgz = shell.exec("find ./build -name *.tar.gz");
 shell.cp(tgz, "./bin-package/");
 shell.pushd("./dist");


### PR DESCRIPTION
got it.
./build/stage/v0.1.18/index-v0.1.18-node-v64-win32-x64.tar.gz
https://travis-ci.com/Connoropolous/holochain-nodejs/jobs/159225335#L2188

The trick is, the same build fails for holochain/holochain-nodejs because of the secret NPM_TOKEN environment var. Same issue we faced when Damien was working on windows CI.
It has been agreed between myself and Nico to disable that part of the CI for now, and get the benefit of the auto-built, auto-published binaries.
This means WE NEED TO MANUALLY publish to NPM when we tag for the time being

Then we'll need to get this merged to the master branch travis file

- [x] remove `publish` stage

To check: Does it work without sudo?

I've disabled `cargo update` in the publish script for now because latest stuff on `develop` branch of holochain-rust has broken this again, for now