### PR TITLE
add json.parse and stringify wrapper around call so devs dont have to

### DIFF
--- a/native/Cargo.lock
+++ b/native/Cargo.lock
@@ -339,7 +339,7 @@ dependencies = [
 [[package]]
 name = "holochain_cas_implementations"
 version = "0.0.1"
-source = "git+https://github.com/holochain/holochain-rust?branch=develop#6692948708b386355894af3759d2286d12ad14a5"
+source = "git+https://github.com/holochain/holochain-rust?branch=develop#13f30a8a1165ae789dca0be3e27a2026c6ff780f"
 dependencies = [
  "futures-preview 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "holochain_core_types 0.0.1 (git+https://github.com/holochain/holochain-rust?branch=develop)",
@@ -361,7 +361,7 @@ dependencies = [
 [[package]]
 name = "holochain_container_api"
 version = "0.0.1"
-source = "git+https://github.com/holochain/holochain-rust?branch=develop#6692948708b386355894af3759d2286d12ad14a5"
+source = "git+https://github.com/holochain/holochain-rust?branch=develop#13f30a8a1165ae789dca0be3e27a2026c6ff780f"
 dependencies = [
  "boolinator 2.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures-preview 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -379,7 +379,7 @@ dependencies = [
 [[package]]
 name = "holochain_core"
 version = "0.0.1"
-source = "git+https://github.com/holochain/holochain-rust?branch=develop#6692948708b386355894af3759d2286d12ad14a5"
+source = "git+https://github.com/holochain/holochain-rust?branch=develop#13f30a8a1165ae789dca0be3e27a2026c6ff780f"
 dependencies = [
  "bitflags 1.0.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "chrono 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -408,7 +408,7 @@ dependencies = [
 [[package]]
 name = "holochain_core_types"
 version = "0.0.1"
-source = "git+https://github.com/holochain/holochain-rust?branch=develop#6692948708b386355894af3759d2286d12ad14a5"
+source = "git+https://github.com/holochain/holochain-rust?branch=develop#13f30a8a1165ae789dca0be3e27a2026c6ff780f"
 dependencies = [
  "arrayref 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "base64 0.10.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -429,7 +429,7 @@ dependencies = [
 [[package]]
 name = "holochain_core_types_derive"
 version = "0.0.1"
-source = "git+https://github.com/holochain/holochain-rust?branch=develop#6692948708b386355894af3759d2286d12ad14a5"
+source = "git+https://github.com/holochain/holochain-rust?branch=develop#13f30a8a1165ae789dca0be3e27a2026c6ff780f"
 dependencies = [
  "quote 0.6.10 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.80 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -440,7 +440,7 @@ dependencies = [
 [[package]]
 name = "holochain_net"
 version = "0.0.1"
-source = "git+https://github.com/holochain/holochain-rust?branch=develop#6692948708b386355894af3759d2286d12ad14a5"
+source = "git+https://github.com/holochain/holochain-rust?branch=develop#13f30a8a1165ae789dca0be3e27a2026c6ff780f"
 dependencies = [
  "base64 0.9.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "failure 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -454,7 +454,7 @@ dependencies = [
 [[package]]
 name = "holochain_net_connection"
 version = "0.1.0"
-source = "git+https://github.com/holochain/holochain-rust?branch=develop#6692948708b386355894af3759d2286d12ad14a5"
+source = "git+https://github.com/holochain/holochain-rust?branch=develop#13f30a8a1165ae789dca0be3e27a2026c6ff780f"
 dependencies = [
  "byteorder 1.2.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "failure 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -471,7 +471,7 @@ dependencies = [
 [[package]]
 name = "holochain_net_ipc"
 version = "0.1.0"
-source = "git+https://github.com/holochain/holochain-rust?branch=develop#6692948708b386355894af3759d2286d12ad14a5"
+source = "git+https://github.com/holochain/holochain-rust?branch=develop#13f30a8a1165ae789dca0be3e27a2026c6ff780f"
 dependencies = [
  "failure 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "holochain_net_connection 0.1.0 (git+https://github.com/holochain/holochain-rust?branch=develop)",
@@ -486,7 +486,7 @@ dependencies = [
 [[package]]
 name = "holochain_wasm_utils"
 version = "0.0.1"
-source = "git+https://github.com/holochain/holochain-rust?branch=develop#6692948708b386355894af3759d2286d12ad14a5"
+source = "git+https://github.com/holochain/holochain-rust?branch=develop#13f30a8a1165ae789dca0be3e27a2026c6ff780f"
 dependencies = [
  "holochain_core_types 0.0.1 (git+https://github.com/holochain/holochain-rust?branch=develop)",
  "holochain_core_types_derive 0.0.1 (git+https://github.com/holochain/holochain-rust?branch=develop)",


### PR DESCRIPTION
There was already a bit of code in the master branch around this, since I accidentally published a commit using github to master

closes #7 

Before:
```javascript
test('use the commit_entry function to add a person entry', (t) => {
  const result = app.call("people", "main", "add_person", JSON.stringify({ name: "Bonnitta" }))
  t.equal(JSON.parse(result).address, "QmWyA4MpWazSQBEh7WLTLdHPFCUk31hbcacnJr87LCWR9T")
  t.end()
})
```

After
```javascript
test('use the commit_entry function to add a person entry', (t) => {
  const result = app.call("people", "main", "add_person", { name: "Bonnitta" })
  t.equal(result.address, "QmWyA4MpWazSQBEh7WLTLdHPFCUk31hbcacnJr87LCWR9T")
  t.end()
})
```